### PR TITLE
Add call tracing functionality.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,13 +4,14 @@ version = "0.1.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
+
+[compat]
+CEnum = "0.4"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test"]
-
-[compat]
-julia = "1.6"
-CEnum = "0.4"

--- a/README.md
+++ b/README.md
@@ -176,6 +176,34 @@ Dict{NSString, NSString} with 1 entry:
 ```
 
 
+## Debugging
+
+To see what ObjectiveC.jl is doing under the hood, you can toggle the `tracing` preference,
+which will make the package print out the Objective-C calls it makes:
+
+```julia
+julia> using ObjectiveC
+julia> ObjectiveC.enable_tracing(true)
+[ Info: ObjectiveC.jl tracing setting changed; restart your Julia session for this change to take effect!
+
+# restart Julia
+
+julia> using ObjectiveC
+
+julia> str = NSString("test");
++ [NSString stringWithUTF8String: (Int8*)0x000000010dc65428]
+  (id<NSString>)0x983d4f92876ccd8c
+
+julia> String(str)
+- [(id<NSString>)0x983d4f92876ccd8c UTF8String]
+  (Int8*)0x000060000376d6a8
+"test"
+```
+
+This can be useful for submitting bug reports to upstream projects which may not be
+familiar with Julia.
+
+
 ## Current status
 
 ObjectiveC.jl has recently been revamped, and is still under heavy development. Do not

--- a/src/ObjectiveC.jl
+++ b/src/ObjectiveC.jl
@@ -2,6 +2,23 @@ module ObjectiveC
 
 using CEnum
 
+using Preferences
+
+"""
+    ObjectiveC.enable_tracing(enabled::Bool)
+
+Enable or disable ObjectiveC.jl tracing, which outputs every Objective-C call made by Julia.
+This is useful for debugging, or to collect traces for submitting bug reports.
+
+The setting is saved in a preference, so is persistent, and requires a restart of Julia to
+take effect.
+"""
+function enable_tracing(enabled::Bool)
+    @set_preferences!("tracing" => enabled)
+    @info("ObjectiveC.jl tracing setting changed; restart your Julia session for this change to take effect!")
+end
+const tracing = @load_preference("tracing", false)::Bool
+
 # Types & Reflection
 include("primitives.jl")
 include("methods.jl")

--- a/src/foundation.jl
+++ b/src/foundation.jl
@@ -175,7 +175,7 @@ end
 NSArray() = NSArray(@objc [NSArray array]::id{NSArray})
 
 function NSArray(elements::Vector)
-    arr = @objc [NSArray arrayWithObjects:elements::Ptr{id}
+    arr = @objc [NSArray arrayWithObjects:elements::Ptr{id{Object}}
                                     count:length(elements)::NSUInteger]::id{NSArray}
     return NSArray(arr)
 end

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -137,6 +137,10 @@ function Base.convert(::Type{id{T}}, x::id{U}) where {T,U}
   Base.bitcast(id{T}, x)
 end
 
+# conversion to integer
+Base.Int(x::id)  = Base.bitcast(Int, x)
+Base.UInt(x::id) = Base.bitcast(UInt, x)
+
 # `reinterpret` can be used to force conversion, typically from untyped `id{Object}`
 Base.reinterpret(::Type{id{T}}, x::id) where {T} = Base.bitcast(id{T}, x)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -242,3 +242,23 @@ using .Dispatch
 end
 
 end
+
+@testset "tracing" begin
+    ObjectiveC.enable_tracing(true)
+    cmd = ```$(Base.julia_cmd()) --project=$(Base.active_project())
+                                 --eval "using ObjectiveC, .Foundation; String(NSString())"```
+
+    out = Pipe()
+    err = Pipe()
+    proc = run(pipeline(cmd, stdout=out, stderr=err), wait=false)
+    close(out.in)
+    close(err.in)
+    wait(proc)
+    out = read(out, String)
+    err = read(err, String)
+
+    @test success(proc)
+    @test isempty(out)
+    @test contains(err, "+ [NSString string]")
+    @test contains(err, r"- \[.+ UTF8String\]")
+end


### PR DESCRIPTION
This should make it easier to file bugs with upstream projects that aren't familiar with Julia:

```julia
julia> using ObjectiveC
julia> ObjectiveC.enable_tracing(true)
[ Info: ObjectiveC.jl tracing setting changed; restart your Julia session for this change to take effect!

# restart Julia

julia> using ObjectiveC

julia> str = NSString("test");
+ [NSString stringWithUTF8String: (Int8*)0x000000010dc65428]
  (id<NSString>)0x983d4f92876ccd8c

julia> String(str)
- [(id<NSString>)0x983d4f92876ccd8c UTF8String]
  (Int8*)0x000060000376d6a8
"test"
```