### PR TITLE
More detailed debug descriptions in show

### DIFF
--- a/src/foundation.jl
+++ b/src/foundation.jl
@@ -28,10 +28,11 @@ export NSObject, retain, release, is_kind_of
 @objcproperties NSObject begin
     @autoproperty hash::NSUInteger
     @autoproperty description::id{NSString}
+    @autoproperty debugDescription::id{NSString}
 end
 
 function Base.show(io::IO, ::MIME"text/plain", obj::NSObject)
-  print(io, String(obj.description))
+  print(io, String(obj.debugDescription))
 end
 
 release(obj::NSObject) = @objc [obj::id{NSObject} release]::Cvoid

--- a/src/foundation.jl
+++ b/src/foundation.jl
@@ -32,7 +32,11 @@ export NSObject, retain, release, is_kind_of
 end
 
 function Base.show(io::IO, ::MIME"text/plain", obj::NSObject)
-  print(io, String(obj.debugDescription))
+  if get(io, :compact, false)
+    print(io, String(obj.description))
+  else
+    print(io, String(obj.debugDescription))
+  end
 end
 
 release(obj::NSObject) = @objc [obj::id{NSObject} release]::Cvoid


### PR DESCRIPTION
Use `debugDescription` instead of `description` for more detailed debug info, which matches the behavior of `lldb po <obj>`.

Example:

```
<MPSMatrix: 0x106b9a4b0>
        Rows:                   3
        Columns:                3
        Matrices:               1
        rowBytes:               12
        matrixBytes:    36
```