### PR TITLE
Minor NSArray improvements

### DIFF
--- a/src/foundation.jl
+++ b/src/foundation.jl
@@ -179,9 +179,12 @@ end
 
 NSArray() = NSArray(@objc [NSArray array]::id{NSArray})
 
-function NSArray(elements::Vector)
-    arr = @objc [NSArray arrayWithObjects:elements::Ptr{id{Object}}
-                                    count:length(elements)::NSUInteger]::id{NSArray}
+function NSArray(elements::Vector{<:NSObject})
+    arr = GC.@preserve elements begin
+        pointers = [element.ptr for element in elements]
+        @objc [NSArray arrayWithObjects:pointers::id{Object}
+                                 count:length(elements)::NSUInteger]::id{NSArray}
+    end
     return NSArray(arr)
 end
 

--- a/src/foundation.jl
+++ b/src/foundation.jl
@@ -13,7 +13,7 @@ else
   const NSInteger = Int32
   const NSUInteger = UInt32
 end
-const MSIntegerMin = typemin(NSInteger)
+const NSIntegerMin = typemin(NSInteger)
 const NSIntegerMax = typemax(NSInteger)
 const NSUIntegerMax = typemax(NSUInteger)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -126,7 +126,7 @@ using .Foundation
 end
 
 @testset "NSHost" begin
-    @test hostname() == gethostname()
+    @test startswith(gethostname(), hostname())
 end
 
 @testset "NSBundle" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -143,6 +143,8 @@ end
     @test reinterpret(NSString, arr2[1]) == "Hello"
     @test reinterpret(NSString, arr2[2]) == "World"
     @test Vector{NSString}(arr2) == arr1
+
+    @test_throws MethodError NSArray([NSUInteger(42)])
 end
 
 @testset "NSDictionary" begin


### PR DESCRIPTION
Fixes https://github.com/JuliaInterop/ObjectiveC.jl/issues/25

This prevents constructing invalid NSArray objects (and likely segfaulting) by both constraining the type signature, and by not using the questionable `Ptr{id{Object}}` type signature (`id` is already a pointer, and relying on Julia's `Ptr` leads to surprising automatic conversion from otherwise incompatible array values).