### PR TITLE
Simplify conversion to array of object pointers.

### DIFF
--- a/src/foundation.jl
+++ b/src/foundation.jl
@@ -180,11 +180,8 @@ end
 NSArray() = NSArray(@objc [NSArray array]::id{NSArray})
 
 function NSArray(elements::Vector{<:NSObject})
-    arr = GC.@preserve elements begin
-        pointers = [element.ptr for element in elements]
-        @objc [NSArray arrayWithObjects:pointers::id{Object}
-                                 count:length(elements)::NSUInteger]::id{NSArray}
-    end
+    arr = @objc [NSArray arrayWithObjects:elements::id{Object}
+                                    count:length(elements)::NSUInteger]::id{NSArray}
     return NSArray(arr)
 end
 


### PR DESCRIPTION
@vtjnash pointed me to RefArray, which `cconvert`s to a temporary struct maintaining roots, in order to safely to recursive conversion of arrays. I've copied the pattern here, as we need to `unsafe_convert` to `id` object pointers and not regular `ptr` pointers.