### PR TITLE
Improve notify center tests.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -287,7 +287,8 @@ end
 end
 
 @testset "notifications" begin
-    for center in [local_notify_center(), darwin_notify_center()]
+    for (center, synchronous) in [(local_notify_center(), true),
+                                  (darwin_notify_center(), false)]
         foo_calls = 0
         bar_calls = 0
         foobar_calls = 0
@@ -308,12 +309,16 @@ end
             add_observer!(center, foobar_observer; name="bar")
 
             post_notification!(center, "foo")
-            run_loop(1; return_after_source_handled=true)
+            if !synchronous
+                run_loop(10; return_after_source_handled=true)
+            end
             @test foo_calls == 1
             @test foobar_calls == 1
 
             post_notification!(center, "bar")
-            run_loop(1; return_after_source_handled=true)
+            if !synchronous
+                run_loop(10; return_after_source_handled=true)
+            end
             @test bar_calls == 1
             @test foobar_calls == 2
 
@@ -321,12 +326,16 @@ end
             remove_observer!(center, foobar_observer; name="foo")
 
             post_notification!(center, "foo")
-            run_loop(1; return_after_source_handled=true)
+            if !synchronous
+                run_loop(10; return_after_source_handled=true)
+            end
             @test foo_calls == 2
             @test foobar_calls == 2
 
             post_notification!(center, "bar")
-            run_loop(1; return_after_source_handled=true)
+            if !synchronous
+                run_loop(10; return_after_source_handled=true)
+            end
             @test bar_calls == 2
             @test foobar_calls == 3
 
@@ -334,7 +343,9 @@ end
             remove_observer!(center, foobar_observer)
 
             post_notification!(center, "bar")
-            run_loop(1; return_after_source_handled=true)
+            if !synchronous
+                run_loop(10; return_after_source_handled=true)
+            end
             @test bar_calls == 3
             @test foobar_calls == 3
         finally


### PR DESCRIPTION
- local notify centers are synchronous, so we shouldn't run the loop. this speeds up testing
- the Darwin notify center is asynchronous, so we should run the loop. do so longer to make the test more robust