### PR TITLE
Add support for NSAutoreleasePool.

### DIFF
--- a/src/foundation.jl
+++ b/src/foundation.jl
@@ -438,7 +438,9 @@ function NSAutoreleasePool(f::Base.Callable)
       f()
     finally
       drain(pool)
-      task.sticky = sticky
+      #task.sticky = sticky
+      # XXX: we cannot safely re-enable thread migration, as the called code might have
+      #      disabled it too. instead, Julia should have a notion of "temporary pinning"
     end
   end
 end


### PR DESCRIPTION
This PR adds support for NSAutoreleasePool, and for running Julia code with an autorelease pool active. This is tricky for two reasons:
- autorelease pools are thread bound, while Julia tasks can migrate threads
- there's no way to switch autorelease pools, while Julia threads can switch between tasks

To work around both, I have a global lock to only ever have one piece of code running under an autorelease pool, while temporarily setting the current task's `sticky` bit to `false` to prevent thread migration.