### PR TITLE
Make NSAutoreleasePool an immutable struct.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ObjectiveC"
 uuid = "e86c9b32-1129-44ac-8ea0-90d5bb39ded9"
-version = "2.0.0"
+version = "2.0.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -113,7 +113,7 @@ using .Foundation
     @objc [obj::id{NSString} release]::id{NSString}
 
     # low-level API
-    let pool=NSAutoreleasePool(; autorelease=false)
+    let pool=NSAutoreleasePool()
         obj = NSString(@objc [NSString new]::id{NSString})
         autorelease(obj)
         drain(pool)


### PR DESCRIPTION
It's often not a good idea to call release anyway. And this improves the performance of the call, avoiding allocations:

```julia
julia> @benchmark @autoreleasepool begin end
BenchmarkTools.Trial: 10000 samples with 807 evaluations.
 Range (min … max):  153.810 ns …  1.562 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     156.651 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   167.710 ns ± 40.671 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▇▅▄▁▁▁▂▁                                         ▂▂         ▁
  █████████▇▇▆█▆▆▄▃▅▄▄▄▄▃▄▄▂▃▄▄▃▄▄▃▂▄▃▃▄▄▄▂▄▃▄▃▃▄▃▄▆████▇▅▆▆▅▃ █
  154 ns        Histogram: log(frequency) by time       308 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```