### PR TITLE
Delay evaluation of signpost arguments.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -427,25 +427,38 @@ end
 
 # specifying a logger
 let
-    @signpost_interval "test" log=OSLog("org.juliainterop.objectivec", "test suite") begin end
+    @signpost_interval log=OSLog() "test" begin end
 end
 
 # specifying begin and end messages
 let
     foo = 41
-    @signpost_interval "test" start="begin $foo" stop="end $bar" begin
+    @signpost_interval start="begin $foo" stop="end $bar" "test" begin
         bar = 42
+    end
+end
+
+# delayed evaluation of inputs
+let
+    @test @signpost_interval log=OSLog(enabled=false) start=error() stop=error() error() begin
+        # the body should still be evaluated
+        true
     end
 end
 end
 
 @testset "event" begin
-signpost_event("test")
-signpost_event("test", "with details")
 
-log = OSLog("org.juliainterop.objectivec", "test suite")
-signpost_event(log, "test", "with details")
+# basic usage
+@signpost_event "test"
+@signpost_event "test" "with details"
+
+# specifying a logger
+@signpost_event log=OSLog() "test" "with details"
 end
+
+# delayed evaluation
+@signpost_event log=OSLog(enabled=false) error() error()
 
 end
 


### PR DESCRIPTION
This makes signpost usage really cheap when the logger is disabled:

```julia
julia> @benchmark @signpost_event log=OSLog(enabled=false) "disabled event"
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  3.125 ns … 15.250 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.208 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.270 ns ±  0.248 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

    ▃ █ ▃ ▂ ▁            ▄ ▂                                 ▁
  ▅▁█▁█▁█▁█▁█▁▇▁▁▇▁▅▁▄▁▆▁█▁█▁▆▁▁█▁▄▁▄▁▄▁▄▁▄▁▅▁▁▃▁▃▁▃▁▄▁▄▁▅▁▃ █
  3.12 ns      Histogram: log(frequency) by time     4.25 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark @signpost_interval log=OSLog(enabled=false) "disabled interval" begin end
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  3.500 ns … 16.000 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     4.667 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   4.816 ns ±  0.721 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

            ▇ ▇  ▆ █  ▃ ▃  ▄ ▆  ▁
  ▁▁▁▁▁▂▃█▆▇█▇██▇██████▆█▆▆█▇█▆▆█▄▆▃▃▄▃▄▂▂▃▂▃▂▂▂▂▂▂▂▃▂▃▁▁▂▁▁ ▃
  3.5 ns         Histogram: frequency by time        6.88 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

Maybe we should do something similar for OSLog, but I don't have a convenient API in mind...