### PR TITLE
Improve the implementation of the stret ABI.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ObjectiveC"
 uuid = "e86c9b32-1129-44ac-8ea0-90d5bb39ded9"
-version = "2.1.2"
+version = "3.0.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/src/abi.jl
+++ b/src/abi.jl
@@ -164,11 +164,11 @@ function classify(dt)
     return cl
 end
 
-@generated use_stret(::Type{T}) where T = classify(T).is_memory
+use_stret(::Type{T}) where T = classify(T).is_memory
 
 elseif Sys.ARCH == :x86
 
-@generated function use_stret(::Type{T}) where T
+function use_stret(::Type{T}) where T
     if sizeof(T) == 0
         return false
     elseif T == ComplexF32 || (isprimitivetype(T) && sizeof(T) <= 8)


### PR DESCRIPTION
As suggested by @vtjnash:

- determine the ABI at parse time, just like ccall
- this avoids the need for a generated function
- let ccall handle the sret box