### PR TITLE
Allow use of `@static` within `@objcproperties`.

### DIFF
--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -454,7 +454,9 @@ macro objcproperties(typ, ex)
         # TODO: liberally support all unknown macros?
         if cmd == Symbol("@static")
             ex = macroexpand(__module__, ex; recursive=false)
-            process_property.(ex.args)
+            if ex !== nothing
+                process_property.(ex.args)
+            end
         else
             push!(properties, (; cmd, args, kwargs))
         end


### PR DESCRIPTION
Replaces https://github.com/JuliaInterop/ObjectiveC.jl/pull/47

cc @christiangnrd; the clue is calling `macroexpand(ex; recursive=false)` (aka. `jl_macroexpand1`) to peel one layer of macros.