### PR TITLE
Follow-up to Availability PR

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ObjectiveC"
 uuid = "e86c9b32-1129-44ac-8ea0-90d5bb39ded9"
-version = "3.4.0"
+version = "3.4.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/src/availability.jl
+++ b/src/availability.jl
@@ -84,9 +84,6 @@ end
 function get_avail_exprs(mod, expr)
     transform_avail_exprs!(expr)
     avail = Base.eval(mod, expr)
-    # if !(avail isa Vector)
-    #     avail = [avail]
-    # end
 
     return avail
 end

--- a/src/availability.jl
+++ b/src/availability.jl
@@ -19,16 +19,14 @@ The currently supported values for `platform` are:
 - `:darwin`: for Darwin kernel availability
 """
 struct PlatformAvailability{P}
-    appl_plat::Bool # Is this Availability object applicable on this system
     introduced::Union{Nothing, VersionNumber}
     deprecated::Union{Nothing, VersionNumber}
     obsoleted::Union{Nothing, VersionNumber}
     unavailable::Bool
 
-
     function PlatformAvailability(p::Symbol, introduced, deprecated = nothing, obsoleted = nothing, unavailable = false)
         haskey(SUPPORTED_PLATFORMS, p) || throw(ArgumentError(lazy"`:$p` is not a supported platform for `PlatformAvailability`, see `?PlatformAvailability` for more information."))
-        return new{p}(SUPPORTED_PLATFORMS[p].plat_func(), introduced, deprecated, obsoleted, unavailable)
+        return new{p}(introduced, deprecated, obsoleted, unavailable)
     end
 end
 PlatformAvailability(platform; introduced = nothing, deprecated = nothing, obsoleted = nothing, unavailable = false) =
@@ -77,7 +75,7 @@ end
 for (name, (pretty_name, version_function)) in SUPPORTED_PLATFORMS
     quotname = Meta.quot(name)
     @eval begin
-        is_available(avail::PlatformAvailability{$quotname}) = !avail.appl_plat || is_available($version_function, avail)
+        is_available(avail::PlatformAvailability{$quotname}) = !SUPPORTED_PLATFORMS[$quotname].plat_func() || is_available($version_function, avail)
         UnavailableError(symbol::Symbol, avail::PlatformAvailability{$quotname}) = UnavailableError($version_function, symbol, $pretty_name, avail)
     end
 end

--- a/src/availability.jl
+++ b/src/availability.jl
@@ -4,9 +4,9 @@ export PlatformAvailability, UnavailableError
 # a symbol of the function used to check the version for that platform, and the function that
 # returns whether that statement applies for this device
 const SUPPORTED_PLATFORMS = Dict(
-    :macos => (pretty_name = "macOS", ver_func = :macos_version, plat_func = Sys.isapple),
-    :darwin => (pretty_name = "Darwin", ver_func = :darwin_version, plat_func = Sys.isapple),
-    :test => (pretty_name = "Never applicable", ver_func = :error, plat_func = () -> false)
+    :macos => ("macOS", :macos_version, Sys.isapple),
+    :darwin => ("Darwin", :darwin_version, Sys.isapple),
+    :test => ("Never applicable", :error, () -> false)
 )
 
 # Based off of Clang's `CXPlatformAvailability`

--- a/src/availability.jl
+++ b/src/availability.jl
@@ -3,9 +3,9 @@ export PlatformAvailability, UnavailableError
 # Each platform tuple has a symbol representing the constructor, a pretty name for errors,
 # a symbol of the function used to check the version for that platform, and the function that
 # returns whether that statement applies for this device
-const SUPPORTED_PLATFORMS = Dict(:macos => ("macOS", :macos_version, Sys.isapple),
-                                 :darwin => ("Darwin", :darwin_version, Sys.isapple),
-                                 :test => ("Never applicable", :error, () -> false))
+const SUPPORTED_PLATFORMS = Dict(:macos => (pretty = "macOS", ver_func = :macos_version, plat_func = Sys.isapple),
+                                 :darwin => (pretty = "Darwin", ver_func = :darwin_version, plat_func = Sys.isapple),
+                                 :test => (pretty = "Never applicable", ver_func = :error, plat_func = () -> false))
 
 # Based off of Clang's `CXPlatformAvailability`
 """
@@ -25,9 +25,10 @@ struct PlatformAvailability{P}
     obsoleted::Union{Nothing, VersionNumber}
     unavailable::Bool
 
-    function PlatformAvailability(platform::Symbol, introduced, deprecated = nothing, obsoleted = nothing, unavailable = false)
-        haskey(SUPPORTED_PLATFORMS, platform) || throw(ArgumentError(lazy"`:$platform` is not a supported platform for `PlatformAvailability`, see `?PlatformAvailability` for more information."))
-        return new{platform}(SUPPORTED_PLATFORMS[platform][3](), introduced, deprecated, obsoleted, unavailable)
+
+    function PlatformAvailability(p::Symbol, introduced, deprecated = nothing, obsoleted = nothing, unavailable = false)
+        haskey(SUPPORTED_PLATFORMS, p) || throw(ArgumentError(lazy"`:$p` is not a supported platform for `PlatformAvailability`, see `?PlatformAvailability` for more information."))
+        return new{p}(SUPPORTED_PLATFORMS[p].plat_func(), introduced, deprecated, obsoleted, unavailable)
     end
 end
 PlatformAvailability(platform; introduced = nothing, deprecated = nothing, obsoleted = nothing, unavailable = false) =

--- a/src/availability.jl
+++ b/src/availability.jl
@@ -64,7 +64,7 @@ function UnavailableError(f::Function, symbol::Symbol, platform::String, avail::
     return UnavailableError(symbol, msg)
 end
 function UnavailableError(symbol::Symbol, avails::Vector{<:PlatformAvailability})
-    firsterror = findfirst(x -> !is_available(x), avails)
+    firsterror = findfirst(!is_available, avails)
     return UnavailableError(symbol, avails[firsterror])
 end
 

--- a/src/availability.jl
+++ b/src/availability.jl
@@ -3,9 +3,11 @@ export PlatformAvailability, UnavailableError
 # Each platform tuple has a symbol representing the constructor, a pretty name for errors,
 # a symbol of the function used to check the version for that platform, and the function that
 # returns whether that statement applies for this device
-const SUPPORTED_PLATFORMS = Dict(:macos => (pretty = "macOS", ver_func = :macos_version, plat_func = Sys.isapple),
-                                 :darwin => (pretty = "Darwin", ver_func = :darwin_version, plat_func = Sys.isapple),
-                                 :test => (pretty = "Never applicable", ver_func = :error, plat_func = () -> false))
+const SUPPORTED_PLATFORMS = Dict(
+    :macos => (pretty = "macOS", ver_func = :macos_version, plat_func = Sys.isapple),
+    :darwin => (pretty = "Darwin", ver_func = :darwin_version, plat_func = Sys.isapple),
+    :test => (pretty = "Never applicable", ver_func = :error, plat_func = () -> false)
+)
 
 # Based off of Clang's `CXPlatformAvailability`
 """

--- a/src/availability.jl
+++ b/src/availability.jl
@@ -1,12 +1,12 @@
 export PlatformAvailability, UnavailableError
 
-# Each platform tuple has a symbol representing the constructor, a pretty name for errors,
+# Each platform tuple has a symbol representing the constructor, a pretty_name name for errors,
 # a symbol of the function used to check the version for that platform, and the function that
 # returns whether that statement applies for this device
 const SUPPORTED_PLATFORMS = Dict(
-    :macos => (pretty = "macOS", ver_func = :macos_version, plat_func = Sys.isapple),
-    :darwin => (pretty = "Darwin", ver_func = :darwin_version, plat_func = Sys.isapple),
-    :test => (pretty = "Never applicable", ver_func = :error, plat_func = () -> false)
+    :macos => (pretty_name = "macOS", ver_func = :macos_version, plat_func = Sys.isapple),
+    :darwin => (pretty_name = "Darwin", ver_func = :darwin_version, plat_func = Sys.isapple),
+    :test => (pretty_name = "Never applicable", ver_func = :error, plat_func = () -> false)
 )
 
 # Based off of Clang's `CXPlatformAvailability`
@@ -74,11 +74,11 @@ function Base.showerror(io::IO, e::UnavailableError)
 end
 
 # Platform-specific definitions
-for (name, (pretty_name, version_function)) in SUPPORTED_PLATFORMS
+for (name, (pretty_name, ver_func, plat_func)) in SUPPORTED_PLATFORMS
     quotname = Meta.quot(name)
     @eval begin
-        is_available(avail::PlatformAvailability{$quotname}) = !SUPPORTED_PLATFORMS[$quotname].plat_func() || is_available($version_function, avail)
-        UnavailableError(symbol::Symbol, avail::PlatformAvailability{$quotname}) = UnavailableError($version_function, symbol, $pretty_name, avail)
+        is_available(avail::PlatformAvailability{$quotname}) = !$plat_func() || is_available($ver_func, avail)
+        UnavailableError(symbol::Symbol, avail::PlatformAvailability{$quotname}) = UnavailableError($ver_func, symbol, $pretty_name, avail)
     end
 end
 

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -311,7 +311,7 @@ macro objcwrapper(ex...)
   end
   immutable = something(immutable, true)
   comparison = something(comparison, !immutable)
-  availability = something(availability, PlatformAvailability(:macos, v"0"))
+  availability = something(availability, PlatformAvailability[])
 
   # parse class definition
   if Meta.isexpr(def, :(<:))
@@ -352,7 +352,7 @@ macro objcwrapper(ex...)
 
     # add a pseudo constructor to the abstract type that also checks for nil pointers.
     function $name(ptr::id)
-      @static if !Sys.isapple() || !ObjectiveC.is_available($availability)
+      @static if !ObjectiveC.is_available($availability)
         throw($UnavailableError(Symbol($name), $availability))
       end
 
@@ -506,7 +506,7 @@ macro objcproperties(typ, ex)
             if haskey(kwargs, :availability)
                 availability = get_avail_exprs(__module__, kwargs[:availability])
             end
-            availability = something(availability, PlatformAvailability(:macos, v"0"))
+            availability = something(availability, PlatformAvailability[])
 
             getterproperty = if haskey(kwargs, :getter)
                 kwargs[:getter]
@@ -515,7 +515,7 @@ macro objcproperties(typ, ex)
             end
             getproperty_ex = objcm(__module__, :([object::id{$(esc(typ))} $getterproperty]::$srcTyp))
             getproperty_ex = quote
-                @static if !Sys.isapple() || !ObjectiveC.is_available($availability)
+                @static if !ObjectiveC.is_available($availability)
                     throw($UnavailableError(Symbol($(esc(typ)), ".", field), $availability))
                 end
                 value = $(Expr(:var"hygienic-scope", getproperty_ex, @__MODULE__, __source__))

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -352,7 +352,7 @@ macro objcwrapper(ex...)
 
     # add a pseudo constructor to the abstract type that also checks for nil pointers.
     function $name(ptr::id)
-      @static if !Sys.isapple() || ObjectiveC.is_unavailable($availability)
+      @static if !Sys.isapple() || !ObjectiveC.is_available($availability)
         throw($UnavailableError(Symbol($name), $availability))
       end
 
@@ -515,7 +515,7 @@ macro objcproperties(typ, ex)
             end
             getproperty_ex = objcm(__module__, :([object::id{$(esc(typ))} $getterproperty]::$srcTyp))
             getproperty_ex = quote
-                @static if !Sys.isapple() || ObjectiveC.is_unavailable($availability)
+                @static if !Sys.isapple() || !ObjectiveC.is_available($availability)
                     throw($UnavailableError(Symbol($(esc(typ)), ".", field), $availability))
                 end
                 value = $(Expr(:var"hygienic-scope", getproperty_ex, @__MODULE__, __source__))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ end
 # Availability
 @objcwrapper availability = macos(v"1000") TestWrapperNoIntro1 <: Object
 @objcwrapper availability = macos(introduced = v"1000") TestWrapperNoIntro2 <: Object
+@objcwrapper availability = test(introduced = v"1000") TestIgnore <: Object
 @objcwrapper availability = macos(deprecated = v"1", obsoleted = v"2.3.4") TestWrapperObsolete <: Object
 @objcwrapper availability = macos(introduced = v"1000", unavailable = true) TestWrapperUnavailable <: Object
 @objcwrapper availability = macos(v"0") TestPropAvail <: Object
@@ -25,6 +26,7 @@ end
 @objcwrapper availability = [macos(v"1000"), darwin(v"0")] TestVectMultiple1 <: Object
 @objcwrapper availability = [macos(v"0"), darwin(v"1000")] TestVectMultiple2 <: Object
 @objcwrapper availability = [macos(v"0"), darwin(v"0")] TestVectMultiple3 <: Object
+@objcwrapper availability = [macos(v"0"), test(v"1000")] TestVectMultiple4 <: Object
 @objcwrapper availability = [macos(v"0")] TestVectAvail <: Object
 @objcproperties TestVectAvail begin
     @autoproperty length::Culong
@@ -40,6 +42,10 @@ end
     let # not yet introduced kwarg version
         fakeidwrap = id{TestWrapperNoIntro2}(1)
         @test_throws "UnavailableError: `TestWrapperNoIntro2` was introduced on macOS v1000.0.0" TestWrapperNoIntro2(fakeidwrap)
+    end
+    let # Not-applicable platform ignored
+        fakeidwrap = id{TestIgnore}(1)
+        @test TestIgnore(fakeidwrap) isa TestIgnore
     end
     let # obsolete
         fakeidwrap = id{TestWrapperObsolete}(1)
@@ -64,6 +70,10 @@ end
     let # Make sure it does not error
         fakeidwrap = id{TestVectMultiple3}(1)
         @test TestVectMultiple3(fakeidwrap) isa TestVectMultiple3
+    end
+    let # Not-applicable platform ignored
+        fakeidwrap = id{TestVectMultiple4}(1)
+        @test TestVectMultiple4(fakeidwrap) isa TestVectMultiple4
     end
 
     # property


### PR DESCRIPTION
Switches `is_unavailable` to `is_available` as mentioned in https://github.com/JuliaInterop/ObjectiveC.jl/pull/51#issuecomment-2651260676.

Also reduces (removes?) places where the code assumes macOS. `PlatformAvailability`s for a different platform are ignored (return `true` when `is_applicable` is called, in line with the Clang availability behaviour.