### PR TITLE
Rework type model: concrete wrappers + parallel Kind-lattice dispatch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,13 @@ version = "3.4.2"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
+ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 
 [compat]
 CEnum = "0.5"
+ExprTools = "0.1"
 Preferences = "1"
 julia = "1.10"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ObjectiveC"
 uuid = "e86c9b32-1129-44ac-8ea0-90d5bb39ded9"
-version = "3.4.2"
+version = "4.0.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/README.md
+++ b/README.md
@@ -41,23 +41,92 @@ julia> obj_ptr = @objc [NSValue valueWithPointer:C_NULL::Ptr{Cvoid}]::id{NSValue
 id{NSValue}(0x00006000023cfca0)
 
 julia> obj = NSValue(obj_ptr)
-NSValueInstance (object of type NSConcreteValue)
+NSValue (object of type NSConcreteValue)
 ```
 
-The generated `NSValue` class is an abstract type that implements the type hierarchy, while
-the `NSValueInstance` object is a concrete structure that houses the `id` pointer. This
-split makes it possible to implement multi-level inheritance and attach functionality at
-each level of the hierarchy, and should be entirely transparent to the user (i.e., you
-should never need to use the `*Instance` types in code or signatures).
-
-The `@objcwrapper` macro also generates conversion routines and accessors that makes it
-possible to use these objects directly with `@objc` calls that require `id` pointers:
+`@objcwrapper` emits a concrete `struct NSValue <: Object` holding the `id` pointer. The
+macro also generates conversion routines so the wrapper can be passed directly to `@objc`
+calls expecting `id`:
 
 ```julia
 julia> get_pointer(val::NSValue) = @objc [val::id{NSValue} pointerValue]::Ptr{Cvoid}
 
 julia> get_pointer(obj)
 Ptr{Nothing} @0x0000000000000000
+```
+
+
+## Type model
+
+Every `@objcwrapper` declaration produces a concrete struct that subtypes the abstract
+`Object` directly, even given chains like `@objcwrapper Foo <: Bar`. Julia's `<:` therefore
+only sees `Foo <: Object`, *not* `Foo <: Bar`. The Objective-C class hierarchy is recorded
+separately as a trait (`objc_parent` / `inherits_from`) that the package walks at compile
+time. Keeping every wrapper concrete avoids the boxing and inference penalties of abstract
+fields, e.g., `Vector{NSString}` is alloc-free, and inference sees a single fixed type
+through container access.
+
+There are three patterns for writing methods, picked by what kind of polymorphism the
+method needs:
+
+**Method on a single class.** Almost everything. Write a normal Julia method against the
+concrete struct:
+
+```julia
+Base.length(s::NSString) = Int(s.length)
+```
+
+This is enough even when ObjC has subclasses of `NSString` at runtime. The actual class of
+the pointer is typically `__NSCFString` or `NSTaggedPointerString`, but since we've only
+`@objcwrapper`'d `NSString`, Julia never sees those subclasses, `typeof(obj)` will
+always be `NSString`, and the ObjectiveC runtime handles dispatch to the real concrete
+class. The same logic applies to Apple framework subclasses you simply haven't wrapped: they
+flow through as the nearest ancestor you *did* wrap.
+
+**Method polymorphic over a class and its subclasses.** When you've reconstructed part of
+the ObjC class hierarchy on the Julia side, i.e. you've written `@objcwrapper Sub <: Parent`,
+and want a method declared on `Parent` to dispatch for `Sub` as well, you should use `@objcdispatch`
+with a `KindOf{T}` argument. The macro emits the canonical body on `KindOf{T}` plus a
+top-level forwarder on `::Object` that routes through `inherits_from`, so callers can pass
+any concrete subclass directly:
+
+```julia
+@objcdispatch endEncoding!(ce::KindOf{MTLCommandEncoder}) =
+    @objc [ce::id{MTLCommandEncoder} endEncoding]::Nothing
+
+# any MTLCommandEncoder subclass flows through
+endEncoding!(blit_encoder)
+```
+
+**Method needs the concrete subclass at runtime.** When the body has to recover the
+caller's type, e.g. to rebuild the return wrapper, `@objcdispatch` is too lossy as it
+erases the subclass to `KindOf{T}`. Two options give you `typeof(kernel)` back:
+
+Enumerate the wrapped subclasses with a `Union` when the set is closed. Julia specializes
+the method per concrete element, no runtime check needed:
+
+```julia
+const MPSKernels = Union{MPSImageGaussianBlur, MPSImageBox, MPSMatrixMultiplication, #= ... =#}
+
+function Base.copy(kernel::MPSKernels)
+    K = typeof(kernel)
+    obj = @objc [kernel::id{MPSKernel} copy]::id{MPSKernel}
+    K(reinterpret(id{K}, obj))
+end
+```
+
+Or write a single method on `::Object` with an explicit `inherits_from` guard when the set
+is open, which results in future `@objcwrapper`'d subclasses being picked up automatically
+without touching the method:
+
+```julia
+function Base.copy(kernel::Object)
+    inherits_from(typeof(kernel), MPSKernel) ||
+        throw(MethodError(copy, (kernel,)))
+    K = typeof(kernel)
+    obj = @objc [kernel::id{MPSKernel} copy]::id{MPSKernel}
+    K(reinterpret(id{K}, obj))
+end
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -58,16 +58,19 @@ Ptr{Nothing} @0x0000000000000000
 
 ## Type model
 
-Every `@objcwrapper` declaration produces a concrete struct that subtypes the abstract
-`Object` directly, even given chains like `@objcwrapper Foo <: Bar`. Julia's `<:` therefore
-only sees `Foo <: Object`, *not* `Foo <: Bar`. The Objective-C class hierarchy is recorded
-separately as a trait (`objc_parent` / `inherits_from`) that the package walks at compile
-time. Keeping every wrapper concrete avoids the boxing and inference penalties of abstract
-fields, e.g., `Vector{NSString}` is alloc-free, and inference sees a single fixed type
-through container access.
+Every `@objcwrapper Foo <: Bar` declaration produces **two** parallel definitions:
 
-There are two patterns for writing methods, picked by what kind of polymorphism the method
-needs:
+  * a concrete `struct Foo <: Object` holding `ptr::id{Foo}`, used for storage and
+    value identity; and
+  * an abstract `FooKind <: BarKind` (defaulting to `<: ObjectKind`), used for
+    dispatch.
+
+The concrete struct chain stays flat: every wrapper is `<: Object` directly, regardless of
+its ObjC parent, so that `Vector{NSString}` is alloc-free and inference sees a single fixed
+type through container access. The Kind lattice mirrors the ObjC class hierarchy and is
+walked by Julia's native multiple dispatch for polymorphic methods.
+
+There are two patterns for writing methods:
 
 **Method on a single class.** Almost everything. Write a normal Julia method against the
 concrete struct:
@@ -84,19 +87,14 @@ same logic applies to Apple framework subclasses you simply haven't wrapped: the
 through as the nearest ancestor you *did* wrap.
 
 **Method polymorphic over a class and its subclasses.** When you've reconstructed part of
-the ObjC class hierarchy on the Julia side, i.e. written `@objcwrapper Sub <: Parent`,
-and want a method declared on `Parent` to dispatch for `Sub` as well, use `@objcdispatch`
-with a `KindOf{T}` argument. `@objcdispatch` has two modes: closed-world (the default)
-and open-world, picked by the dispatch boundary the method has to honour.
-
-*Closed-world* (`@objcdispatch f(...)`) is the right choice when the set of subclasses is
-**fully known to the macro at expansion time**, typically because every `@objcwrapper Sub
-<: Parent` lives in the same module above the method. At expansion the macro substitutes
-`KindOf{T}` with `Union{T, descendants(T)...}`, where descendants come from walking the
-`objc_parent` method table. The result is a regular Julia method on a concrete Union,
-dispatched natively:
+the ObjC class hierarchy on the Julia side, i.e. written `@objcwrapper Sub <: Parent`, and
+want a method declared on `Parent` to dispatch for `Sub` as well, use `@objcdispatch` with a
+`KindOf{T}` argument:
 
 ```julia
+@objcdispatch release(obj::KindOf{NSObject}) =
+    @objc [obj::id{NSObject} release]::Cvoid
+
 @objcdispatch endEncoding!(ce::KindOf{MTLCommandEncoder}) =
     @objc [ce::id{MTLCommandEncoder} endEncoding]::Nothing
 
@@ -107,28 +105,10 @@ dispatched natively:
 end
 ```
 
-*Open-world* (`@objcdispatch open=true f(...)`) is the right choice when the method should
-remain available to wrappers declared by **other modules or packages**, e.g., `retain`,
-`release`, `==`, and other foundation primitives are the canonical examples. In this case,
-the macro substitutes `KindOf{T}` with the abstract apex `Object` (so any wrapper matches
-dispatch) and prepends a runtime guard `inherits_from(typeof(arg), T) ||
-throw(MethodError(f, ...))` to the method body:
-
-```julia
-@objcdispatch open=true release(obj::KindOf{NSObject}) =
-    @objc [obj::id{NSObject} release]::Cvoid
-```
-
-Only one `open=true` definition is supported per function name. Because each `open=true`
-method rewrites its `KindOf{T}` slot to `::Object`, a second one on the same function would
-collide at `f(::Object, …)` and silently clobber the first. This is intentional: the
-canonical pattern is a single open-world root (every NSObject primitive has exactly one),
-and class-specific specialization should be a plain (closed-world) method on the concrete
-subclass, whose signature is strictly more specific than `::Object` so Julia's dispatch will
-prefer it.
-
-Rule of thumb: **closed-world when the dispatch set is owned by one module; open-world
-when the method should outlive any one package's view of the hierarchy.**
+For each `KindOf{T}` argument, `@objcdispatch` emits a body method dispatched on the Kind
+lattice and forwards calls with `Object` arguments to it. When the argument's static type is
+known at the call site (the common case), the entry-then-body chain folds at compile time to
+a direct call; the trait dispatch is zero-cost.
 
 
 ## Properties

--- a/README.md
+++ b/README.md
@@ -119,13 +119,21 @@ throw(MethodError(f, ...))` to the method body:
     @objc [obj::id{NSObject} release]::Cvoid
 ```
 
+Only one `open=true` definition is supported per function name. Because each `open=true`
+method rewrites its `KindOf{T}` slot to `::Object`, a second one on the same function would
+collide at `f(::Object, …)` and silently clobber the first. This is intentional: the
+canonical pattern is a single open-world root (every NSObject primitive has exactly one),
+and class-specific specialization should be a plain (closed-world) method on the concrete
+subclass, whose signature is strictly more specific than `::Object` so Julia's dispatch will
+prefer it.
+
 Rule of thumb: **closed-world when the dispatch set is owned by one module; open-world
 when the method should outlive any one package's view of the hierarchy.**
 
 
 ## Properties
 
-A common pattern in Objective-C is to use properties to acces instance variables. Although
+A common pattern in Objective-C is to use properties to access instance variables. Although
 it is possible to access these directly using `@objc`, ObjectiveC.jl provides a macro to
 automatically generate the appropriate `getproperty`, `setproperty!` and `propertynames`
 definitions:

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ time. Keeping every wrapper concrete avoids the boxing and inference penalties o
 fields, e.g., `Vector{NSString}` is alloc-free, and inference sees a single fixed type
 through container access.
 
-There are three patterns for writing methods, picked by what kind of polymorphism the
-method needs:
+There are two patterns for writing methods, picked by what kind of polymorphism the method
+needs:
 
 **Method on a single class.** Almost everything. Write a normal Julia method against the
 concrete struct:
@@ -78,17 +78,15 @@ Base.length(s::NSString) = Int(s.length)
 
 This is enough even when ObjC has subclasses of `NSString` at runtime. The actual class of
 the pointer is typically `__NSCFString` or `NSTaggedPointerString`, but since we've only
-`@objcwrapper`'d `NSString`, Julia never sees those subclasses, `typeof(obj)` will
-always be `NSString`, and the ObjectiveC runtime handles dispatch to the real concrete
-class. The same logic applies to Apple framework subclasses you simply haven't wrapped: they
-flow through as the nearest ancestor you *did* wrap.
+`@objcwrapper`'d `NSString`, Julia never sees those subclasses, `typeof(obj)` will always
+be `NSString`, and the ObjectiveC runtime handles dispatch to the real concrete class. The
+same logic applies to Apple framework subclasses you simply haven't wrapped: they flow
+through as the nearest ancestor you *did* wrap.
 
 **Method polymorphic over a class and its subclasses.** When you've reconstructed part of
-the ObjC class hierarchy on the Julia side, i.e. you've written `@objcwrapper Sub <: Parent`,
-and want a method declared on `Parent` to dispatch for `Sub` as well, you should use `@objcdispatch`
-with a `KindOf{T}` argument. The macro emits the canonical body on `KindOf{T}` plus a
-top-level forwarder on `::Object` that routes through `inherits_from`, so callers can pass
-any concrete subclass directly:
+the ObjC class hierarchy on the Julia side — i.e. written `@objcwrapper Sub <: Parent` —
+and want a method declared on `Parent` to dispatch for `Sub` as well, use `@objcdispatch`
+with a `KindOf{T}` argument:
 
 ```julia
 @objcdispatch endEncoding!(ce::KindOf{MTLCommandEncoder}) =
@@ -98,36 +96,24 @@ any concrete subclass directly:
 endEncoding!(blit_encoder)
 ```
 
-**Method needs the concrete subclass at runtime.** When the body has to recover the
-caller's type, e.g. to rebuild the return wrapper, `@objcdispatch` is too lossy as it
-erases the subclass to `KindOf{T}`. Two options give you `typeof(kernel)` back:
-
-Enumerate the wrapped subclasses with a `Union` when the set is closed. Julia specializes
-the method per concrete element, no runtime check needed:
+`KindOf{T}` is a macro-level marker: at macro-expansion time `@objcdispatch` substitutes
+it with `Union{T, descendants(T)...}`, where descendants come from walking the
+`objc_parent` method table. The result is a regular Julia method on a concrete Union,
+dispatched natively — `typeof(arg)` inside the body is the concrete subclass, which lets
+you rebuild the return wrapper or otherwise specialize:
 
 ```julia
-const MPSKernels = Union{MPSImageGaussianBlur, MPSImageBox, MPSMatrixMultiplication, #= ... =#}
-
-function Base.copy(kernel::MPSKernels)
+@objcdispatch function Base.copy(kernel::KindOf{MPSKernel})
     K = typeof(kernel)
     obj = @objc [kernel::id{MPSKernel} copy]::id{MPSKernel}
     K(reinterpret(id{K}, obj))
 end
 ```
 
-Or write a single method on `::Object` with an explicit `inherits_from` guard when the set
-is open, which results in future `@objcwrapper`'d subclasses being picked up automatically
-without touching the method:
-
-```julia
-function Base.copy(kernel::Object)
-    inherits_from(typeof(kernel), MPSKernel) ||
-        throw(MethodError(copy, (kernel,)))
-    K = typeof(kernel)
-    obj = @objc [kernel::id{MPSKernel} copy]::id{MPSKernel}
-    K(reinterpret(id{K}, obj))
-end
-```
+The Union is frozen at macro expansion. **`@objcwrapper Sub <: Parent` must come before
+any `@objcdispatch` on `KindOf{Parent}` or its ancestors** — otherwise the existing method
+won't dispatch on `Sub`, and a warning fires from `@objcwrapper` pointing at the affected
+call site.
 
 
 ## Properties

--- a/README.md
+++ b/README.md
@@ -46,69 +46,83 @@ NSValue (object of type NSConcreteValue)
 
 `@objcwrapper` emits a concrete `struct NSValue <: Object` holding the `id` pointer. The
 macro also generates conversion routines so the wrapper can be passed directly to `@objc`
-calls expecting `id`:
+calls expecting `id`.
+
+To declare a method on a wrapper class, use `@objcmethod` with a `KindOf{T}` argument
+marker:
 
 ```julia
-julia> get_pointer(val::NSValue) = @objc [val::id{NSValue} pointerValue]::Ptr{Cvoid}
+julia> @objcmethod get_pointer(val::KindOf{NSValue}) =
+           @objc [val::id{NSValue} pointerValue]::Ptr{Cvoid}
 
 julia> get_pointer(obj)
 Ptr{Nothing} @0x0000000000000000
 ```
+
+`KindOf{T}` in combination with `@objcmethod` makes the method polymorphic over `T` and any
+wrapped subclasses; important because wrappers do *not* form a Julia `<:` chain (every
+wrapper is `<: Object` directly), so a plain `f(val::NSValue, …)` would silently fail to
+dispatch on a subclass.
 
 
 ## Type model
 
 Every `@objcwrapper Foo <: Bar` declaration produces **two** parallel definitions:
 
-  * a concrete `struct Foo <: Object` holding `ptr::id{Foo}`, used for storage and
-    value identity; and
-  * an abstract `FooKind <: BarKind` (defaulting to `<: ObjectKind`), used for
-    dispatch.
+* a concrete `struct Foo <: Object` holding `ptr::id{Foo}`, for storage and value identity;
+* an abstract `FooKind <: BarKind` (defaulting to `<: ObjectKind`), for dispatch purposes.
 
 The concrete struct chain stays flat: every wrapper is `<: Object` directly, regardless of
 its ObjC parent, so that `Vector{NSString}` is alloc-free and inference sees a single fixed
 type through container access. The Kind lattice mirrors the ObjC class hierarchy and is
 walked by Julia's native multiple dispatch for polymorphic methods.
 
-There are two patterns for writing methods:
+### Methods on wrapper classes
 
-**Method on a single class.** Almost everything. Write a normal Julia method against the
-concrete struct:
-
-```julia
-Base.length(s::NSString) = Int(s.length)
-```
-
-This is enough even when ObjC has subclasses of `NSString` at runtime. The actual class of
-the pointer is typically `__NSCFString` or `NSTaggedPointerString`, but since we've only
-`@objcwrapper`'d `NSString`, Julia never sees those subclasses, `typeof(obj)` will always
-be `NSString`, and the ObjectiveC runtime handles dispatch to the real concrete class. The
-same logic applies to Apple framework subclasses you simply haven't wrapped: they flow
-through as the nearest ancestor you *did* wrap.
-
-**Method polymorphic over a class and its subclasses.** When you've reconstructed part of
-the ObjC class hierarchy on the Julia side, i.e. written `@objcwrapper Sub <: Parent`, and
-want a method declared on `Parent` to dispatch for `Sub` as well, use `@objcdispatch` with a
-`KindOf{T}` argument:
+**Recommendation: use `@objcmethod` with `KindOf{T}` for wrapper-typed parameters.** Because
+the concrete struct chain is flat, a plain `f(x::Parent, …)` is monomorphic and does *not*
+match a later `@objcwrapper Sub <: Parent`. To avoid this footgun, route every wrapper-typed
+argument through `@objcmethod` and mark it with `KindOf{T}`:
 
 ```julia
-@objcdispatch release(obj::KindOf{NSObject}) =
+@objcmethod release(obj::KindOf{NSObject}) =
     @objc [obj::id{NSObject} release]::Cvoid
 
-@objcdispatch endEncoding!(ce::KindOf{MTLCommandEncoder}) =
+@objcmethod endEncoding!(ce::KindOf{MTLCommandEncoder}) =
     @objc [ce::id{MTLCommandEncoder} endEncoding]::Nothing
 
-@objcdispatch function Base.copy(kernel::KindOf{MPSKernel})
+@objcmethod function Base.copy(kernel::KindOf{MPSKernel})
     K = typeof(kernel)
     obj = @objc [kernel::id{MPSKernel} copy]::id{MPSKernel}
     K(reinterpret(id{K}, obj))
 end
 ```
 
-For each `KindOf{T}` argument, `@objcdispatch` emits a body method dispatched on the Kind
-lattice and forwards calls with `Object` arguments to it. When the argument's static type is
-known at the call site (the common case), the entry-then-body chain folds at compile time to
-a direct call; the trait dispatch is zero-cost.
+For each `KindOf{T}` slot, `@objcmethod` emits a body method dispatched on the parallel
+Kind lattice and an entry forwarder on `::Object` that routes calls to it. When the
+argument's static type is known at the call site (the common case), the chain folds at
+compile time to a direct call; the trait dispatch is zero-cost.
+
+`KindOf{T}` is **macro-level syntax**, not a real Julia type. `@objcmethod` rewrites every
+`KindOf{T}` slot at macroexpand-time and the marker never reaches runtime, so it cannot
+appear in containers, fields, or return positions — `Vector{KindOf{T}}`, `id{KindOf{T}}`,
+and `f(…)::KindOf{T}` are all meaningless. The storage axis is unaffected by the choice
+of dispatch style: `Vector{NSString}` is still tightly packed, and the wrapper struct
+remains an immutable `isbits` value carrying a single `id` pointer regardless of whether
+methods on it use `@objcmethod`.
+
+**When to write a plain method instead.** Skipping `@objcmethod` is fine when:
+
+* The class is a true leaf with no `@objcwrapper` subclasses (e.g. `NSString`, where the
+  underlying `__NSCFString` / `NSTaggedPointerString` subclasses are *not* wrapped on the
+  Julia side and so `typeof(obj)` is always `NSString`). The ObjC runtime still
+  dispatches to the real concrete class via `objc_msgSend`, so a normal
+  `Base.length(s::NSString) = Int(s.length)` works correctly.
+* You genuinely want to refuse subclasses (rare in Objective-C, where messaging is
+  polymorphic by design).
+
+In all other cases, prefer `@objcmethod`: it costs only a runtime type check while
+protecting the method from breaking when a downstream `@objcwrapper Sub <: Parent` lands.
 
 
 ## Properties

--- a/README.md
+++ b/README.md
@@ -84,25 +84,22 @@ same logic applies to Apple framework subclasses you simply haven't wrapped: the
 through as the nearest ancestor you *did* wrap.
 
 **Method polymorphic over a class and its subclasses.** When you've reconstructed part of
-the ObjC class hierarchy on the Julia side — i.e. written `@objcwrapper Sub <: Parent` —
+the ObjC class hierarchy on the Julia side, i.e. written `@objcwrapper Sub <: Parent`,
 and want a method declared on `Parent` to dispatch for `Sub` as well, use `@objcdispatch`
-with a `KindOf{T}` argument:
+with a `KindOf{T}` argument. `@objcdispatch` has two modes — closed-world (the default)
+and open-world — picked by the dispatch boundary the method has to honour.
+
+*Closed-world* (`@objcdispatch f(...)`) is the right choice when the set of subclasses is
+**fully known to the macro at expansion time**, typically because every `@objcwrapper Sub
+<: Parent` lives in the same module above the method. At expansion the macro substitutes
+`KindOf{T}` with `Union{T, descendants(T)...}`, where descendants come from walking the
+`objc_parent` method table. The result is a regular Julia method on a concrete Union,
+dispatched natively:
 
 ```julia
 @objcdispatch endEncoding!(ce::KindOf{MTLCommandEncoder}) =
     @objc [ce::id{MTLCommandEncoder} endEncoding]::Nothing
 
-# any MTLCommandEncoder subclass flows through
-endEncoding!(blit_encoder)
-```
-
-`KindOf{T}` is a macro-level marker: at macro-expansion time `@objcdispatch` substitutes
-it with `Union{T, descendants(T)...}`, where descendants come from walking the
-`objc_parent` method table. The result is a regular Julia method on a concrete Union,
-dispatched natively — `typeof(arg)` inside the body is the concrete subclass, which lets
-you rebuild the return wrapper or otherwise specialize:
-
-```julia
 @objcdispatch function Base.copy(kernel::KindOf{MPSKernel})
     K = typeof(kernel)
     obj = @objc [kernel::id{MPSKernel} copy]::id{MPSKernel}
@@ -110,10 +107,33 @@ you rebuild the return wrapper or otherwise specialize:
 end
 ```
 
-The Union is frozen at macro expansion. **`@objcwrapper Sub <: Parent` must come before
-any `@objcdispatch` on `KindOf{Parent}` or its ancestors** — otherwise the existing method
-won't dispatch on `Sub`, and a warning fires from `@objcwrapper` pointing at the affected
-call site.
+The Union is **frozen at macro expansion**: `@objcwrapper Sub <: Parent` must come before
+any closed-world `@objcdispatch` on `KindOf{Parent}` or its ancestors, or `Sub` won't flow
+through the existing method (the `@objcwrapper` fires a warning pointing at the affected
+call site).
+
+*Open-world* (`@objcdispatch open=true f(...)`) is the right choice when the method should
+remain available to wrappers declared by **other modules or packages** — `retain`,
+`release`, `==`, `is_kind_of` and other foundation primitives are the canonical examples.
+Instead of freezing a Union, the macro substitutes `KindOf{T}` with the abstract apex
+`Object` (so any wrapper matches dispatch) and prepends a runtime guard
+`inherits_from(typeof(arg), T) || throw(MethodError(f, ...))` to the method body:
+
+```julia
+@objcdispatch open=true release(obj::KindOf{NSObject}) =
+    @objc [obj::id{NSObject} release]::Cvoid
+```
+
+`release` now applies to every wrapper declared anywhere downstream — Metal's `MTLBuffer`,
+MPS kernels, user types — without any re-declaration, and a non-`NSObject` argument is
+rejected with a clear `MethodError`. The runtime guard is `@inline`d through
+`inherits_from`, so for the typical call site where the concrete arg type is statically
+known, the check folds at compile time and the open-world variant compiles to the same
+code as the closed-world one. Open-world methods do not register a stale-Union watcher,
+so subsequent `@objcwrapper`s never warn about them.
+
+Rule of thumb: **closed-world when the dispatch set is owned by one module; open-world
+when the method should outlive any one package's view of the hierarchy.**
 
 
 ## Properties

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ through as the nearest ancestor you *did* wrap.
 **Method polymorphic over a class and its subclasses.** When you've reconstructed part of
 the ObjC class hierarchy on the Julia side, i.e. written `@objcwrapper Sub <: Parent`,
 and want a method declared on `Parent` to dispatch for `Sub` as well, use `@objcdispatch`
-with a `KindOf{T}` argument. `@objcdispatch` has two modes — closed-world (the default)
-and open-world — picked by the dispatch boundary the method has to honour.
+with a `KindOf{T}` argument. `@objcdispatch` has two modes: closed-world (the default)
+and open-world, picked by the dispatch boundary the method has to honour.
 
 *Closed-world* (`@objcdispatch f(...)`) is the right choice when the set of subclasses is
 **fully known to the macro at expansion time**, typically because every `@objcwrapper Sub
@@ -107,30 +107,17 @@ dispatched natively:
 end
 ```
 
-The Union is **frozen at macro expansion**: `@objcwrapper Sub <: Parent` must come before
-any closed-world `@objcdispatch` on `KindOf{Parent}` or its ancestors, or `Sub` won't flow
-through the existing method (the `@objcwrapper` fires a warning pointing at the affected
-call site).
-
 *Open-world* (`@objcdispatch open=true f(...)`) is the right choice when the method should
-remain available to wrappers declared by **other modules or packages** — `retain`,
-`release`, `==`, `is_kind_of` and other foundation primitives are the canonical examples.
-Instead of freezing a Union, the macro substitutes `KindOf{T}` with the abstract apex
-`Object` (so any wrapper matches dispatch) and prepends a runtime guard
-`inherits_from(typeof(arg), T) || throw(MethodError(f, ...))` to the method body:
+remain available to wrappers declared by **other modules or packages**, e.g., `retain`,
+`release`, `==`, and other foundation primitives are the canonical examples. In this case,
+the macro substitutes `KindOf{T}` with the abstract apex `Object` (so any wrapper matches
+dispatch) and prepends a runtime guard `inherits_from(typeof(arg), T) ||
+throw(MethodError(f, ...))` to the method body:
 
 ```julia
 @objcdispatch open=true release(obj::KindOf{NSObject}) =
     @objc [obj::id{NSObject} release]::Cvoid
 ```
-
-`release` now applies to every wrapper declared anywhere downstream — Metal's `MTLBuffer`,
-MPS kernels, user types — without any re-declaration, and a non-`NSObject` argument is
-rejected with a clear `MethodError`. The runtime guard is `@inline`d through
-`inherits_from`, so for the typical call site where the concrete arg type is statically
-known, the check folds at compile time and the open-world variant compiles to the same
-code as the closed-world one. Open-world methods do not register a stale-Union watcher,
-so subsequent `@objcwrapper`s never warn about them.
 
 Rule of thumb: **closed-world when the dispatch set is owned by one module; open-world
 when the method should outlive any one package's view of the hierarchy.**

--- a/src/ObjectiveC.jl
+++ b/src/ObjectiveC.jl
@@ -2,6 +2,8 @@ module ObjectiveC
 
 using CEnum
 
+using ExprTools: splitdef, combinedef
+
 using Preferences
 
 """

--- a/src/foundation.jl
+++ b/src/foundation.jl
@@ -33,7 +33,7 @@ export NSObject, retain, release, autorelease, is_kind_of
     @autoproperty retainCount::NSUInteger
 end
 
-function Base.show(io::IO, ::MIME"text/plain", obj::NSObject)
+function Base.show(io::IO, ::MIME"text/plain", obj::Object)
     if get(io, :compact, false)
         print(io, String(obj.description))
     else
@@ -41,19 +41,22 @@ function Base.show(io::IO, ::MIME"text/plain", obj::NSObject)
     end
 end
 
-release(obj::NSObject) = @objc [obj::id{NSObject} release]::Cvoid
+# Methods that ObjC defines on NSObject (so available on every ObjC object).
+# We type them on `Object` directly so any wrapper participates without an
+# Interface{NSObject} wrapper.
+release(obj::Object) = @objc [obj::id{NSObject} release]::Cvoid
 
-autorelease(obj::NSObject) = @objc [obj::id{NSObject} autorelease]::Cvoid
+autorelease(obj::Object) = @objc [obj::id{NSObject} autorelease]::Cvoid
 
-retain(obj::NSObject) = @objc [obj::id{NSObject} retain]::Cvoid
+retain(obj::Object) = @objc [obj::id{NSObject} retain]::Cvoid
 
-ObjectiveC.class(obj::NSObject) = @objc [obj::id{NSObject} class]::Class
-
-function is_kind_of(obj::NSObject, class::Class)
+function is_kind_of(obj::Object, class::Class)
     @objc [obj::id{NSObject} isKindOfClass:class::Class]::Bool
 end
 
-function Base.:(==)(obj1::NSObject, obj2::NSObject)
+# Default equality for ObjC objects via `isEqual:`. Specific classes can
+# override this for a faster path (NSString, NSURL, etc. already do).
+function Base.:(==)(obj1::Object, obj2::Object)
     @objc [obj1::id{NSObject} isEqual:obj2::id{NSObject}]::Bool
 end
 
@@ -299,7 +302,7 @@ end
 
 NSArray() = NSArray(@objc [NSArray array]::id{NSArray})
 
-function NSArray(elements::Vector{<:NSObject})
+function NSArray(elements::Vector{<:Object})
     arr = @objc [NSArray arrayWithObjects:elements::id{Object}
                                     count:length(elements)::NSUInteger]::id{NSArray}
     return NSArray(arr)
@@ -335,7 +338,7 @@ end
 
 NSDictionary() = NSDictionary(@objc [NSDictionary dictionary]::id{NSDictionary})
 
-function NSDictionary(items::Dict{<:NSObject,<:NSObject})
+function NSDictionary(items::Dict{<:Object,<:Object})
     nskeys = NSArray(collect(keys(items)))
     nsvals = NSArray(collect(values(items)))
     dict = @objc [NSDictionary dictionaryWithObjects:nsvals::id{NSArray}
@@ -349,7 +352,7 @@ Base.isempty(dict::NSDictionary) = length(dict) == 0
 Base.keys(dict::NSDictionary) = dict.allKeys
 Base.values(dict::NSDictionary) = dict.allValues
 
-function Base.getindex(dict::NSDictionary, key::NSObject)
+function Base.getindex(dict::NSDictionary, key::Object)
     ptr = @objc [dict::id{NSDictionary} objectForKey:key::id{NSObject}]::id{Object}
     ptr == nil && throw(KeyError(key))
     return ptr

--- a/src/foundation.jl
+++ b/src/foundation.jl
@@ -33,14 +33,13 @@ export NSObject, retain, release, autorelease, is_kind_of
     @autoproperty retainCount::NSUInteger
 end
 
-# Methods defined by ObjC on NSObject. We use `@objcdispatch open=true` so
-# the dispatch is open to any wrapper a downstream package declares (Metal,
-# MPS, user code) without requiring re-declaration: the macro dispatches on
-# `::Object` and emits a runtime `inherits_from(typeof(obj), NSObject)`
-# guard, so a non-NSObject `Object` subtype gets a clear `MethodError`
-# rather than an obscure `convert(id{NSObject}, …)` failure.
-@objcdispatch open=true function Base.show(io::IO, ::MIME"text/plain",
-                                            obj::KindOf{NSObject})
+# Methods defined by ObjC on NSObject. `@objcdispatch` dispatches through
+# the Kind lattice, so downstream wrappers (Metal, MPS, user code) automatically
+# participate without re-declaration: `classkind(typeof(obj)) <: NSObjectKind`
+# routes through the trait-dispatched body, while a non-NSObject `Object`
+# subtype hits a clean `MethodError` on the body method.
+@objcdispatch function Base.show(io::IO, ::MIME"text/plain",
+                                 obj::KindOf{NSObject})
     if get(io, :compact, false)
         print(io, String(obj.description))
     else
@@ -48,23 +47,23 @@ end
     end
 end
 
-@objcdispatch open=true release(obj::KindOf{NSObject}) =
+@objcdispatch release(obj::KindOf{NSObject}) =
     @objc [obj::id{NSObject} release]::Cvoid
 
-@objcdispatch open=true autorelease(obj::KindOf{NSObject}) =
+@objcdispatch autorelease(obj::KindOf{NSObject}) =
     @objc [obj::id{NSObject} autorelease]::Cvoid
 
-@objcdispatch open=true retain(obj::KindOf{NSObject}) =
+@objcdispatch retain(obj::KindOf{NSObject}) =
     @objc [obj::id{NSObject} retain]::Cvoid
 
-@objcdispatch open=true function is_kind_of(obj::KindOf{NSObject}, class::Class)
+@objcdispatch function is_kind_of(obj::KindOf{NSObject}, class::Class)
     @objc [obj::id{NSObject} isKindOfClass:class::Class]::Bool
 end
 
 # Default equality for ObjC objects via `isEqual:`. Specific classes can
 # override this for a faster path (NSString, NSURL, etc. already do).
-@objcdispatch open=true function Base.:(==)(obj1::KindOf{NSObject},
-                                             obj2::KindOf{NSObject})
+@objcdispatch function Base.:(==)(obj1::KindOf{NSObject},
+                                  obj2::KindOf{NSObject})
     @objc [obj1::id{NSObject} isEqual:obj2::id{NSObject}]::Bool
 end
 

--- a/src/foundation.jl
+++ b/src/foundation.jl
@@ -33,7 +33,14 @@ export NSObject, retain, release, autorelease, is_kind_of
     @autoproperty retainCount::NSUInteger
 end
 
-function Base.show(io::IO, ::MIME"text/plain", obj::Object)
+# Methods defined by ObjC on NSObject. We use `@objcdispatch open=true` so
+# the dispatch is open to any wrapper a downstream package declares (Metal,
+# MPS, user code) without requiring re-declaration: the macro dispatches on
+# `::Object` and emits a runtime `inherits_from(typeof(obj), NSObject)`
+# guard, so a non-NSObject `Object` subtype gets a clear `MethodError`
+# rather than an obscure `convert(id{NSObject}, …)` failure.
+@objcdispatch open=true function Base.show(io::IO, ::MIME"text/plain",
+                                            obj::KindOf{NSObject})
     if get(io, :compact, false)
         print(io, String(obj.description))
     else
@@ -41,22 +48,23 @@ function Base.show(io::IO, ::MIME"text/plain", obj::Object)
     end
 end
 
-# Methods that ObjC defines on NSObject (so available on every ObjC object).
-# We type them on `Object` directly so any wrapper participates without an
-# Interface{NSObject} wrapper.
-release(obj::Object) = @objc [obj::id{NSObject} release]::Cvoid
+@objcdispatch open=true release(obj::KindOf{NSObject}) =
+    @objc [obj::id{NSObject} release]::Cvoid
 
-autorelease(obj::Object) = @objc [obj::id{NSObject} autorelease]::Cvoid
+@objcdispatch open=true autorelease(obj::KindOf{NSObject}) =
+    @objc [obj::id{NSObject} autorelease]::Cvoid
 
-retain(obj::Object) = @objc [obj::id{NSObject} retain]::Cvoid
+@objcdispatch open=true retain(obj::KindOf{NSObject}) =
+    @objc [obj::id{NSObject} retain]::Cvoid
 
-function is_kind_of(obj::Object, class::Class)
+@objcdispatch open=true function is_kind_of(obj::KindOf{NSObject}, class::Class)
     @objc [obj::id{NSObject} isKindOfClass:class::Class]::Bool
 end
 
 # Default equality for ObjC objects via `isEqual:`. Specific classes can
 # override this for a faster path (NSString, NSURL, etc. already do).
-function Base.:(==)(obj1::Object, obj2::Object)
+@objcdispatch open=true function Base.:(==)(obj1::KindOf{NSObject},
+                                             obj2::KindOf{NSObject})
     @objc [obj1::id{NSObject} isEqual:obj2::id{NSObject}]::Bool
 end
 

--- a/src/foundation.jl
+++ b/src/foundation.jl
@@ -33,12 +33,12 @@ export NSObject, retain, release, autorelease, is_kind_of
     @autoproperty retainCount::NSUInteger
 end
 
-# Methods defined by ObjC on NSObject. `@objcdispatch` dispatches through
+# Methods defined by ObjC on NSObject. `@objcmethod` dispatches through
 # the Kind lattice, so downstream wrappers (Metal, MPS, user code) automatically
 # participate without re-declaration: `classkind(typeof(obj)) <: NSObjectKind`
 # routes through the trait-dispatched body, while a non-NSObject `Object`
 # subtype hits a clean `MethodError` on the body method.
-@objcdispatch function Base.show(io::IO, ::MIME"text/plain",
+@objcmethod function Base.show(io::IO, ::MIME"text/plain",
                                  obj::KindOf{NSObject})
     if get(io, :compact, false)
         print(io, String(obj.description))
@@ -47,22 +47,22 @@ end
     end
 end
 
-@objcdispatch release(obj::KindOf{NSObject}) =
+@objcmethod release(obj::KindOf{NSObject}) =
     @objc [obj::id{NSObject} release]::Cvoid
 
-@objcdispatch autorelease(obj::KindOf{NSObject}) =
+@objcmethod autorelease(obj::KindOf{NSObject}) =
     @objc [obj::id{NSObject} autorelease]::Cvoid
 
-@objcdispatch retain(obj::KindOf{NSObject}) =
+@objcmethod retain(obj::KindOf{NSObject}) =
     @objc [obj::id{NSObject} retain]::Cvoid
 
-@objcdispatch function is_kind_of(obj::KindOf{NSObject}, class::Class)
+@objcmethod function is_kind_of(obj::KindOf{NSObject}, class::Class)
     @objc [obj::id{NSObject} isKindOfClass:class::Class]::Bool
 end
 
 # Default equality for ObjC objects via `isEqual:`. Specific classes can
 # override this for a faster path (NSString, NSURL, etc. already do).
-@objcdispatch function Base.:(==)(obj1::KindOf{NSObject},
+@objcmethod function Base.:(==)(obj1::KindOf{NSObject},
                                   obj2::KindOf{NSObject})
     @objc [obj1::id{NSObject} isEqual:obj2::id{NSObject}]::Bool
 end

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -132,11 +132,9 @@ Base.:(==)(x::Ptr, y::id) = throw(ArgumentError("Cannot compare id with Ptr"))
 function Base.convert(::Type{id{T}}, x::id{U}) where {T,U}
     # nil is an exception (we want to be able to use `nil` in `@objc` directly)
     x == nil && return Base.bitcast(id{T}, nil)
-    # allow conversion to a Julia supertype, or up an Objective-C inheritance
-    # chain (encoded by `inherits_from`, which is forward-declared and defined
-    # in syntax.jl). When both U and T are concrete leaf classes, Julia's `<:`
-    # alone is insufficient — every `@objcwrapper` class is <:Object but not
-    # <:its-ObjC-parent.
+    # allow conversion to a Julia supertype, or up an Objective-C inheritance chain (encoded
+    # by `inherits_from`). When both U and T are concrete leaf classes, Julia's `<:` alone
+    # is insufficient, since every `@objcwrapper` class is <:Object but not <:its-ObjC-parent.
     if !(U <: T) && !(compatible_id_types(T, U)::Bool)
         throw(ArgumentError("Cannot convert id{$U} to id{$T}"))
     end

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -132,10 +132,20 @@ Base.:(==)(x::Ptr, y::id) = throw(ArgumentError("Cannot compare id with Ptr"))
 function Base.convert(::Type{id{T}}, x::id{U}) where {T,U}
     # nil is an exception (we want to be able to use `nil` in `@objc` directly)
     x == nil && return Base.bitcast(id{T}, nil)
-    # otherwise, types must match (i.e., only allow converting to a supertype)
-    U <: T || throw(ArgumentError("Cannot convert id{$U} to id{$T}"))
+    # allow conversion to a Julia supertype, or up an Objective-C inheritance
+    # chain (encoded by `inherits_from`, which is forward-declared and defined
+    # in syntax.jl). When both U and T are concrete leaf classes, Julia's `<:`
+    # alone is insufficient — every `@objcwrapper` class is <:Object but not
+    # <:its-ObjC-parent.
+    if !(U <: T) && !(compatible_id_types(T, U)::Bool)
+        throw(ArgumentError("Cannot convert id{$U} to id{$T}"))
+    end
     Base.bitcast(id{T}, x)
 end
+
+# default: only Julia subtyping. syntax.jl extends this to use `inherits_from`
+# for the Object hierarchy.
+compatible_id_types(::Type, ::Type) = false
 
 # conversion to integer
 Base.Int(x::id)  = Base.bitcast(Int, x)
@@ -153,12 +163,12 @@ Base.unsafe_convert(::Type{P}, x::id) where {P<:id} = convert(P, x)
 
 # Objects
 
-# Object is an abstract type, so that we can define subtypes with constructors.
-# The expected interface is that any subtype of Object should be convertible to id.
-
+# Object is the sole abstract supertype of every Objective-C wrapper. Each
+# `@objcwrapper` declaration emits a concrete `struct`/`mutable struct` that
+# inherits directly from `Object`. The Objective-C class hierarchy is encoded
+# via a recursive `inherits_from` trait (see syntax.jl) rather than via
+# Julia's `<:` relation.
 abstract type Object end
-# interface: subtypes of Object should be convertible to `id`s
-#            (i.e., `Base.unsafe_convert(::Type{id}, ::MyObj)`)
 
 const nil = id{Object}(0)
 
@@ -171,10 +181,3 @@ class(obj::Union{Object,id}) =
 Base.methods(obj::Union{Object,id}) = methods(class(obj))
 
 Base.show(io::IO, obj::T) where {T <: Object} = print(io, "$T (object of type ", class(obj), ")")
-
-struct UnknownObject <: Object
-    ptr::id
-    UnknownObject(ptr::id) = new(ptr)
-end
-Base.unsafe_convert(T::Type{<:id}, obj::UnknownObject) = convert(T, obj.ptr)
-Object(ptr::id) = UnknownObject(ptr)

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -81,11 +81,11 @@ end
 # to warn when a subclass is declared after methods on its ancestor —
 # such methods will not dispatch on `Sub`, because their Union was frozen
 # at the time `@objcdispatch` was processed.
-const objcdispatch_sites = IdDict{Type, Vector{NamedTuple{(:name, :file, :line), Tuple{Symbol, String, Int}}}}()
+const objcdispatch_sites = IdDict{Type, Vector{NamedTuple{(:name, :file, :line), Tuple{String, String, Int}}}}()
 
-function register_objcdispatch_site!(P::Type, name::Symbol, file::AbstractString, line::Integer)
-    sites = get!(() -> NamedTuple{(:name, :file, :line), Tuple{Symbol, String, Int}}[], objcdispatch_sites, P)
-    entry = (name=name, file=String(file), line=Int(line))
+function register_objcdispatch_site!(P::Type, name::AbstractString, file::AbstractString, line::Integer)
+    sites = get!(() -> NamedTuple{(:name, :file, :line), Tuple{String, String, Int}}[], objcdispatch_sites, P)
+    entry = (name=String(name), file=String(file), line=Int(line))
     entry in sites || push!(sites, entry)
     return
 end
@@ -579,11 +579,13 @@ macro objcdispatch(ex...)
 
     ex = decl
     # Accept `@objcdispatch @inline function ... end` style by unwrapping
-    # leading macro decorators (e.g. `@inline`, `@noinline`).
-    decorators = Any[]
+    # leading macro decorators (e.g. `@inline`, `@noinline`,
+    # `@autoreleasepool unsafe=true`). Save each macrocall in full so the
+    # macro name, original LineNumberNode, and any intermediate kwargs are
+    # preserved when we re-wrap below.
+    decorators = Expr[]
     while Meta.isexpr(ex, :macrocall)
-        # Drop the LineNumberNode in macrocalls (args[2])
-        push!(decorators, ex.args[1])
+        push!(decorators, ex)
         ex = ex.args[end]
     end
 
@@ -725,7 +727,9 @@ macro objcdispatch(ex...)
 
     method_def = Expr(:function, new_sig, body)
     for dec in reverse(decorators)
-        method_def = Expr(:macrocall, dec, LineNumberNode(0), method_def)
+        # Re-emit the original macrocall with the new function body in the
+        # trailing slot, preserving every other arg (LineNumberNode, kwargs).
+        method_def = Expr(:macrocall, dec.args[1:end-1]..., method_def)
     end
 
     # Register this call site under every parent T so a later `@objcwrapper
@@ -735,9 +739,12 @@ macro objcdispatch(ex...)
     # there is no stale Union to warn about).
     src_file = String(__source__.file)
     src_line = Int(__source__.line)
-    fname_q = QuoteNode(fname isa Symbol ? fname : Symbol(fname))
+    # Store the function name as a String so qualified spellings
+    # (`Base.show`, `MyMod.foo`) round-trip into the late-subclass warning
+    # faithfully — `Symbol(Expr)` would mangle them via `string`.
+    fname_str = string(fname)
     register_calls = open ? Expr[] : [
-        :( $ObjectiveC.register_objcdispatch_site!($P, $fname_q, $src_file, $src_line) )
+        :( $ObjectiveC.register_objcdispatch_site!($P, $fname_str, $src_file, $src_line) )
         for P in unique(parent_types) if !isabstracttype(P)
     ]
 

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -91,9 +91,8 @@ function warn_late_subclass(child::Type, parent::Type)
             for site in objcdispatch_sites[p]
                 @warn """`@objcwrapper $child <: $parent` declared after `@objcdispatch \
                          $(site.name)(::KindOf{$p}, …)` at $(site.file):$(site.line). \
-                         The existing method will not dispatch on $child; redeclare the \
-                         `@objcdispatch` after the `@objcwrapper`, or move the wrapper \
-                         above the methods."""
+                         The existing method will not dispatch on $child; move the \
+                         `@objcwrapper` above the `@objcdispatch`."""
             end
         end
         p === Object && break
@@ -536,7 +535,7 @@ The substitution is frozen at macro expansion. **Wrappers must be declared
 before any `@objcdispatch` method that should dispatch on them.** Declaring a
 subclass via `@objcwrapper Sub <: Parent` *after* an `@objcdispatch` on
 `KindOf{Parent}` will fire a warning; `Sub` won't flow through the existing
-method until you redeclare it.
+method until the `@objcwrapper` is moved above it.
 
 Modeled on Objective-C's `__kindof T *` type qualifier.
 """

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -959,20 +959,17 @@ macro objcproperties(typ, ex)
         end
     end
 
-    # generate `Base.getproperty` / `objc_getproperty` definitions.
-    # We define `objc_getproperty(::Type{T}, obj, field)` rather than
-    # `Base.getproperty` directly, so the ObjC parent chain can be walked at
-    # runtime via `objc_parent` (replacing the old `invoke(getproperty,
-    # supertype(T), ...)` chain). The wrapper `Base.getproperty(obj::T, field) =
-    # objc_getproperty(T, obj, field)` is the user-facing entry. The
-    # per-class method is `@inline`d so a literal `obj.length` propagates the
-    # field symbol through both forwarders, letting Julia fold the
-    # `if field === :length` cascade and infer the precise return type
-    # (without it, the body's return type degrades to the Union of every
-    # property type in the ancestor chain).
+    # generate `Base.getproperty` / `objc_getproperty` definitions. We define
+    # `objc_getproperty(::Type{T}, obj, field)` rather than `Base.getproperty` directly, so
+    # the ObjC parent chain can be walked at runtime via `objc_parent`. The wrapper
+    # `Base.getproperty(obj::T, field) = objc_getproperty(T, obj, field)` is the user-facing
+    # entry. The per-class method is `@inline`d so a literal `obj.length` propagates the
+    # field symbol through both forwarders, letting Julia fold the `if field === :length`
+    # cascade and infer the precise return type (without it, the body's return type degrades
+    # to the Union of every property type in the ancestor chain).
     #
-    # `obj` is intentionally left untyped — the same method must also serve
-    # `KindOf{T}` wrappers, which are not `<:Object`.
+    # `obj` is intentionally left untyped, as the same method must also serve `KindOf{T}`
+    # wrappers, which are not `<:Object`.
     getproperties_ex = quote end
     if !isempty(read_properties)
         current = nothing

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -892,9 +892,12 @@ macro objcproperties(typ, ex)
     # `Base.getproperty` directly, so the ObjC parent chain can be walked at
     # runtime via `objc_parent` (replacing the old `invoke(getproperty,
     # supertype(T), ...)` chain). The wrapper `Base.getproperty(obj::T, field) =
-    # objc_getproperty(T, obj, field)` is the user-facing entry. Julia
-    # specializes `objc_getproperty` per concrete `obj` type at the call site
-    # so type-stability is preserved through the chain.
+    # objc_getproperty(T, obj, field)` is the user-facing entry. The
+    # per-class method is `@inline`d so a literal `obj.length` propagates the
+    # field symbol through both forwarders, letting Julia fold the
+    # `if field === :length` cascade and infer the precise return type
+    # (without it, the body's return type degrades to the Union of every
+    # property type in the ancestor chain).
     #
     # `obj` is intentionally left untyped — the same method must also serve
     # `KindOf{T}` wrappers, which are not `<:Object`.
@@ -918,7 +921,7 @@ macro objcproperties(typ, ex)
                     $ObjectiveC.objc_parent($(esc(typ))), object, field))
         push!(current.args, final)
         getproperties_ex = quote
-            function $ObjectiveC.objc_getproperty(::Type{$(esc(typ))}, object, field::Symbol)
+            @inline function $ObjectiveC.objc_getproperty(::Type{$(esc(typ))}, object, field::Symbol)
                 $getproperties_ex
             end
         end
@@ -945,8 +948,8 @@ macro objcproperties(typ, ex)
                     $ObjectiveC.objc_parent($(esc(typ))), object, field, value))
         push!(current.args, final)
         setproperties_ex = quote
-            function $ObjectiveC.objc_setproperty!(::Type{$(esc(typ))}, object,
-                                                    field::Symbol, value::Any)
+            @inline function $ObjectiveC.objc_setproperty!(::Type{$(esc(typ))}, object,
+                                                            field::Symbol, value::Any)
                 $setproperties_ex
             end
         end

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -594,40 +594,43 @@ macro objcdispatch(ex)
         return false
     end
 
-    # Locate the `KindOf{T}` argument; remember the type parameter T.
-    iface_idx = nothing
-    iface_T = nothing
+    # Locate every `KindOf{T}` argument and remember each type parameter T.
+    # All slots are substituted independently — `f(::KindOf{A}, ::KindOf{B})`
+    # produces a method with both slots expanded to their respective Unions.
+    # The arg may be named (`x::T`, length 2) or anonymous (`::T`, length 1).
+    kindof_slots = Tuple{Int, Any}[]
     for (i, a) in enumerate(args)
-        if Meta.isexpr(a, :(::)) && is_kindof_type(a.args[2])
-            iface_idx = i
-            iface_T = a.args[2].args[2]
-            break
-        end
+        Meta.isexpr(a, :(::)) || continue
+        typ = a.args[end]
+        is_kindof_type(typ) || continue
+        push!(kindof_slots, (i, typ.args[2]))
     end
-    iface_idx === nothing &&
-        wrappererror("@objcdispatch needs one argument typed `KindOf{T}`")
+    isempty(kindof_slots) &&
+        wrappererror("@objcdispatch needs at least one argument typed `KindOf{T}`")
 
-    # Resolve T (the `KindOf{T}` parameter) in the user's module so we can
-    # compute the dispatch Union at macroexpand time.
-    P = try
-        Core.eval(__module__, iface_T)
-    catch err
-        wrappererror("@objcdispatch could not resolve `$iface_T` (must be a wrapped class declared earlier): $err")
-    end
-    P isa Type && P <: Object ||
-        wrappererror("@objcdispatch type parameter `$iface_T` must resolve to a subtype of `Object`, got $P")
-
-    union_type = objc_kindof_type(P)
-
-    # Substitute `KindOf{P}` with the Union at the matched arg slot.
+    # Resolve every T in the user's module so we can compute each dispatch
+    # Union at macroexpand time. Substitute each slot in turn.
     new_args = copy(args)
-    iface_a = args[iface_idx]
-    iface_arg_name = if Meta.isexpr(iface_a, :(::)) && length(iface_a.args) == 2
-        iface_a.args[1]
-    else
-        gensym(:_)
+    parent_types = Type[]
+    for (idx, T_expr) in kindof_slots
+        P = try
+            Core.eval(__module__, T_expr)
+        catch err
+            wrappererror("@objcdispatch could not resolve `$T_expr` (must be a wrapped class declared earlier): $err")
+        end
+        P isa Type && P <: Object ||
+            wrappererror("@objcdispatch type parameter `$T_expr` must resolve to a subtype of `Object`, got $P")
+        push!(parent_types, P)
+
+        union_type = objc_kindof_type(P)
+        a = args[idx]
+        arg_name = if Meta.isexpr(a, :(::)) && length(a.args) == 2
+            a.args[1]
+        else
+            gensym(:_)
+        end
+        new_args[idx] = :( $arg_name::$union_type )
     end
-    new_args[iface_idx] = :( $iface_arg_name::$union_type )
 
     # Reconstruct the signature (with kwargs, where, ret).
     new_sig = Expr(:call, fname, new_args...)
@@ -646,16 +649,19 @@ macro objcdispatch(ex)
         method_def = Expr(:macrocall, dec, LineNumberNode(0), method_def)
     end
 
-    # Register this call site so a later `@objcwrapper Sub <: P` can warn that
-    # the Union is now stale.
+    # Register this call site under every parent T so a later `@objcwrapper
+    # Sub <: T` can warn that the Union is now stale.
     src_file = String(__source__.file)
     src_line = Int(__source__.line)
     fname_q = QuoteNode(fname isa Symbol ? fname : Symbol(fname))
-    register_call = :( $ObjectiveC.register_objcdispatch_site!($P, $fname_q, $src_file, $src_line) )
+    register_calls = [
+        :( $ObjectiveC.register_objcdispatch_site!($P, $fname_q, $src_file, $src_line) )
+        for P in unique(parent_types)
+    ]
 
     esc(quote
         Core.@__doc__ $method_def
-        $register_call
+        $(register_calls...)
     end)
 end
 

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -1,4 +1,4 @@
-export @objc, @objcwrapper, @objcproperties, @objcblock, @objcdispatch
+export @objc, @objcwrapper, @objcproperties, @objcblock, @objcmethod
 export KindOf
 
 
@@ -8,7 +8,7 @@ export KindOf
 # Each `@objcwrapper Foo <: Bar` emits `abstract type FooKind <: BarKind end`
 # alongside the concrete `struct Foo <: Object`. The concrete types stay flat
 # (so `Vector{Foo}` is unboxed), while `classkind(::Type{Foo}) = FooKind`
-# lets `@objcdispatch` dispatch through the Kind lattice via Julia's native
+# lets `@objcmethod` dispatch through the Kind lattice via Julia's native
 # multiple dispatch. There's no registration, no late-subclass warning, and
 # no closed-vs-open distinction — Julia's type lattice does all the work.
 #
@@ -28,7 +28,7 @@ objc_parent(::Type{Object}) = nothing
 objc_parent(::Type{<:Object}) = nothing
 
 
-# `KindOf{T}` is a parse-time marker recognized by `@objcdispatch` in
+# `KindOf{T}` is a parse-time marker recognized by `@objcmethod` in
 # argument positions. The struct itself is never instantiated — the macro
 # rewrites each `KindOf{T}` slot into trait dispatch on `Type{<:classkind(T)}`.
 # Modeled on Objective-C's `__kindof T *` type qualifier.
@@ -314,7 +314,7 @@ ObjC layer without forcing a Julia abstract type for each non-leaf class.
 
 Methods can be written directly on the concrete struct (e.g.
 `length(s::NSString) = ...`); polymorphic methods over an inheritance chain
-should be expressed via [`@objcdispatch`](@ref).
+should be expressed via [`@objcmethod`](@ref).
 
 Keyword arguments:
 
@@ -397,7 +397,7 @@ macro objcwrapper(ex...)
     end
 
     # Emit the parallel abstract `${name}Kind <: classkind(super)` for trait
-    # dispatch via `@objcdispatch`. `classkind(super)` is resolved at the
+    # dispatch via `@objcmethod`. `classkind(super)` is resolved at the
     # declaration site, so the super's Kind type must already exist (same
     # ordering rule as the concrete struct's `<:Object`).
     kindname = Symbol(name, "Kind")
@@ -405,7 +405,7 @@ macro objcwrapper(ex...)
     ex = quote
         $(structdef.args...)
 
-        # parallel Kind type, used by `@objcdispatch` for subclass dispatch.
+        # parallel Kind type, used by `@objcmethod` for subclass dispatch.
         abstract type $kindname <: $ObjectiveC.classkind($super) end
         $ObjectiveC.classkind(::Type{$name}) = $kindname
 
@@ -459,7 +459,7 @@ Base.unsafe_convert(T::Type{<:id}, arr::idArray) =
 
 
 """
-    @objcdispatch f(arg::KindOf{T}, more...)::ret begin
+    @objcmethod f(arg::KindOf{T}, more...)::ret begin
         # body
     end
 
@@ -473,7 +473,7 @@ The macro lowers each `KindOf{T}` slot to trait dispatch on the parallel
   * a body method `f(::Type{<:classkind(T)}, x, more...) = …`, dispatched
     on the Kind of the actual argument's class;
   * an entry forwarder `f(x::Object, more...) = f(classkind(typeof(x)), x, more...)`,
-    which is identical across all `@objcdispatch` sites for the same `f`
+    which is identical across all `@objcmethod` sites for the same `f`
     (Julia will simply redefine it, harmlessly).
 
 Multiple `KindOf{T}` slots are each lowered the same way; the trait
@@ -488,14 +488,14 @@ registration, and no late-subclass warning needed.
 runtime type intact. When the argument's static type is known at the call
 site, the trait dispatch folds through both methods to a direct call.
 """
-macro objcdispatch(ex...)
+macro objcmethod(ex...)
     decl = ex[end]
     isempty(ex[1:end-1]) ||
-        wrappererror("@objcdispatch no longer accepts keyword arguments; \
-                      drop `open=true` (every `@objcdispatch` is now open by construction)")
+        wrappererror("@objcmethod no longer accepts keyword arguments; \
+                      drop `open=true` (every `@objcmethod` is now open by construction)")
 
     ex = decl
-    # Accept `@objcdispatch @inline function ... end` style by unwrapping
+    # Accept `@objcmethod @inline function ... end` style by unwrapping
     # leading macro decorators (e.g. `@inline`, `@noinline`,
     # `@autoreleasepool unsafe=true`). Save each macrocall in full so the
     # macro name, original LineNumberNode, and any intermediate kwargs are
@@ -513,13 +513,13 @@ macro objcdispatch(ex...)
     def = try
         splitdef(ex)
     catch err
-        wrappererror("@objcdispatch expects a function definition ($err)")
+        wrappererror("@objcmethod expects a function definition ($err)")
     end
     args        = get(def, :args, Any[])::Vector
     kwargs      = get(def, :kwargs, Any[])::Vector
     whereparams = get(def, :whereparams, Any[])::Vector
     fname       = def[:name]
-    isempty(args) && wrappererror("@objcdispatch needs at least one positional argument typed `KindOf{T}`")
+    isempty(args) && wrappererror("@objcmethod needs at least one positional argument typed `KindOf{T}`")
 
     # Recognize `KindOf{T}` and any qualified form ending in `KindOf{T}`
     # (e.g. `ObjectiveC.KindOf{T}`, `OC.KindOf{T}`).
@@ -541,7 +541,7 @@ macro objcdispatch(ex...)
         push!(kindof_slots, (i, typ.args[2]))
     end
     isempty(kindof_slots) &&
-        wrappererror("@objcdispatch needs at least one argument typed `KindOf{T}`")
+        wrappererror("@objcmethod needs at least one argument typed `KindOf{T}`")
 
     # Name every positional arg (gensym anonymous ones) so the entry
     # forwarder can pass them through to the body method.
@@ -564,10 +564,10 @@ macro objcdispatch(ex...)
         P = try
             Core.eval(__module__, T_expr)
         catch err
-            wrappererror("@objcdispatch could not resolve `$T_expr` (must be a wrapped class declared earlier): $err")
+            wrappererror("@objcmethod could not resolve `$T_expr` (must be a wrapped class declared earlier): $err")
         end
         P isa Type && P <: Object ||
-            wrappererror("@objcdispatch type parameter `$T_expr` must resolve to a subtype of `Object`, got $P")
+            wrappererror("@objcmethod type parameter `$T_expr` must resolve to a subtype of `Object`, got $P")
     end
 
     # Helper: rewrite the user's positional args into the entry-side shape —
@@ -619,7 +619,7 @@ macro objcdispatch(ex...)
         :body => fwd_call,
     ))
 
-    # Two `@objcdispatch` sites for the same function with disjoint
+    # Two `@objcmethod` sites for the same function with disjoint
     # `KindOf{T}` roots but otherwise identical args produce the same entry
     # signature. Emitting it twice is "method overwriting", which Julia 1.12
     # rejects during precompile. Guard the entry with a top-level check
@@ -648,7 +648,7 @@ macro objcdispatch(ex...)
 end
 
 # True iff `f` has a method whose signature is *exactly* `Tuple{typeof(f),
-# argtypes.parameters...}` — used by `@objcdispatch` to decide whether the
+# argtypes.parameters...}` — used by `@objcmethod` to decide whether the
 # entry forwarder is already in place. `hasmethod` would be too loose
 # (`hasmethod(==, Tuple{Object, Object})` is true via `==(::Any, ::Any)`).
 function has_exact_method(@nospecialize(f), @nospecialize(argtypes::Type))

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -527,26 +527,57 @@ Base.unsafe_convert(T::Type{<:id}, arr::idArray) =
 
 
 """
-    @objcdispatch f(arg::KindOf{T}, more...)::ret begin
-        # body — `arg` is typed as `Union{T, descendants(T)...}`
+    @objcdispatch [open=false] f(arg::KindOf{T}, more...)::ret begin
+        # body
     end
 
-Define a polymorphic Objective-C method on the class `T` and every currently
-wrapped subclass of `T`. The macro substitutes `KindOf{T}` at expansion time
-with `Union{T, descendants...}`, where descendants come from walking the
-`objc_parent` method table. The result is a regular Julia method on a concrete
-Union, dispatched natively — `typeof(arg)` inside the body is the concrete
-subclass.
+Define a polymorphic Objective-C method on the class `T`. Two dispatch
+modes are supported, picked via the `open` keyword argument:
 
-The substitution is frozen at macro expansion. **Wrappers must be declared
-before any `@objcdispatch` method that should dispatch on them.** Declaring a
-subclass via `@objcwrapper Sub <: Parent` *after* an `@objcdispatch` on
-`KindOf{Parent}` will fire a warning; `Sub` won't flow through the existing
-method until the `@objcwrapper` is moved above it.
+  * `open=false` (default) — **closed-world dispatch.** The macro substitutes
+    `KindOf{T}` at expansion time with `Union{T, descendants...}`, where
+    descendants come from walking the `objc_parent` method table. The result
+    is a regular Julia method on a concrete Union, dispatched natively —
+    `typeof(arg)` inside the body is the concrete subclass. The substitution
+    is frozen; subclasses declared *after* the method via `@objcwrapper
+    Sub <: T` will not flow through it, and a warning fires from the
+    subsequent `@objcwrapper` pointing at the affected call site. Use this
+    mode for methods scoped to a sub-hierarchy fully owned by one module.
 
-Modeled on Objective-C's `__kindof T *` type qualifier.
+  * `open=true` — **open-world dispatch.** The macro substitutes `KindOf{T}`
+    with the abstract apex `Object`, so any current or future wrapper
+    matches dispatch, and prepends a runtime guard
+    `inherits_from(typeof(arg), T) || throw(MethodError(f, (...,)))` to the
+    method body. The call site is not registered (no late-subclass warning).
+    Use this mode for methods that should remain available to any wrapper
+    declared by downstream packages — for example, foundation primitives
+    like `retain`/`release`/`==` that semantically apply to every
+    `KindOf{NSObject}` regardless of which package introduces the subclass.
+
+Both modes use the same `KindOf{T}` spelling at the call site. Modeled on
+Objective-C's `__kindof T *` type qualifier.
 """
-macro objcdispatch(ex)
+macro objcdispatch(ex...)
+    decl = ex[end]
+    kwargs = ex[1:end-1]
+
+    # Parse keyword arguments. Only `open=Bool` is supported.
+    open = false
+    for kw in kwargs
+        if kw isa Expr && kw.head == :(=)
+            key, value = kw.args
+            if key == :open
+                value isa Bool || wrappererror("`open` keyword argument must be a literal boolean")
+                open = value
+            else
+                wrappererror("unrecognized keyword argument: $key")
+            end
+        else
+            wrappererror("invalid keyword argument: $kw")
+        end
+    end
+
+    ex = decl
     # Accept `@objcdispatch @inline function ... end` style by unwrapping
     # leading macro decorators (e.g. `@inline`, `@noinline`).
     decorators = Any[]
@@ -617,10 +648,28 @@ macro objcdispatch(ex)
     isempty(kindof_slots) &&
         wrappererror("@objcdispatch needs at least one argument typed `KindOf{T}`")
 
-    # Resolve every T in the user's module so we can compute each dispatch
-    # Union at macroexpand time. Substitute each slot in turn.
+    # Ensure every positional arg has a name we can reference, both for the
+    # substituted signature and (under `open=true`) for the `MethodError`
+    # tuple. Anonymous-typed args (`::T`) get a gensym; the names are stable
+    # across both passes below.
+    arg_names = Symbol[]
+    for a in args
+        if Meta.isexpr(a, :(::))
+            push!(arg_names, length(a.args) == 2 ? a.args[1] : gensym(:_))
+        elseif a isa Symbol
+            push!(arg_names, a)
+        else
+            push!(arg_names, gensym(:_))
+        end
+    end
+
+    # Resolve every T in the user's module. With `open=false`, substitute
+    # `KindOf{T}` with the closed-world `Union{T, descendants...}`. With
+    # `open=true`, substitute with the apex `Object` so any wrapper matches
+    # dispatch — the runtime guard emitted below enforces the actual T.
     new_args = copy(args)
     parent_types = Type[]
+    open_guards = Tuple{Symbol, Type}[]
     for (idx, T_expr) in kindof_slots
         P = try
             Core.eval(__module__, T_expr)
@@ -631,14 +680,35 @@ macro objcdispatch(ex)
             wrappererror("@objcdispatch type parameter `$T_expr` must resolve to a subtype of `Object`, got $P")
         push!(parent_types, P)
 
-        union_type = objc_kindof_type(P)
-        a = args[idx]
-        arg_name = if Meta.isexpr(a, :(::)) && length(a.args) == 2
-            a.args[1]
+        name = arg_names[idx]
+        if open
+            new_args[idx] = :( $name::$ObjectiveC.Object )
+            push!(open_guards, (name, P))
         else
-            gensym(:_)
+            new_args[idx] = :( $name::$(objc_kindof_type(P)) )
         end
-        new_args[idx] = :( $arg_name::$union_type )
+    end
+
+    # Re-emit anonymous-typed positional args with their gensym name so the
+    # `MethodError` tuple under `open=true` can reference every arg.
+    if open
+        for (i, a) in enumerate(args)
+            if Meta.isexpr(a, :(::)) && length(a.args) == 1 && new_args[i] === a
+                new_args[i] = :( $(arg_names[i])::$(a.args[1]) )
+            end
+        end
+        # Prepend the runtime guard for each `KindOf{T}` arg. The first
+        # mismatching arg throws a `MethodError` carrying every positional
+        # arg, mirroring the message Julia would produce had dispatch failed.
+        guard = Expr(:block)
+        args_tuple = Expr(:tuple, arg_names...)
+        for (name, P) in open_guards
+            push!(guard.args, :(
+                $ObjectiveC.inherits_from(typeof($name), $P) ||
+                    throw(MethodError($fname, $args_tuple))
+            ))
+        end
+        body = Expr(:block, guard, body)
     end
 
     # Reconstruct the signature (with kwargs, where, ret).
@@ -659,12 +729,14 @@ macro objcdispatch(ex)
     end
 
     # Register this call site under every parent T so a later `@objcwrapper
-    # Sub <: T` can warn that the Union is now stale. Skip abstract Ts: their
-    # Union collapses to `T` and Julia's `<:` already covers any subclass.
+    # Sub <: T` can warn that the Union is now stale. Skip abstract Ts (their
+    # Union collapses to `T`) and skip every site under `open=true` (the
+    # method already dispatches via `::Object` and re-checks at runtime, so
+    # there is no stale Union to warn about).
     src_file = String(__source__.file)
     src_line = Int(__source__.line)
     fname_q = QuoteNode(fname isa Symbol ? fname : Symbol(fname))
-    register_calls = [
+    register_calls = open ? Expr[] : [
         :( $ObjectiveC.register_objcdispatch_site!($P, $fname_q, $src_file, $src_line) )
         for P in unique(parent_types) if !isabstracttype(P)
     ]

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -474,11 +474,14 @@ macro objcwrapper(ex...)
         # `objc_getproperty`/`objc_setproperty!` per class to install
         # autoproperty branches; without that, the chain walks straight to the
         # parent via `objc_parent`, all the way up to `Object` where it falls
-        # back to `getfield`/`setfield!`.
+        # back to `getfield`/`setfield!`. `propertynames` follows the same
+        # chain via `objc_propertynames` so children without their own
+        # `@objcproperties` block still surface their ancestors' properties.
         Base.getproperty(object::$name, field::Symbol) =
             $ObjectiveC.objc_getproperty($name, object, field)
         Base.setproperty!(object::$name, field::Symbol, value::Any) =
             $ObjectiveC.objc_setproperty!($name, object, field, value)
+        Base.propertynames(::$name) = $ObjectiveC.objc_propertynames($name)
 
         # Warn if any ancestor already has `@objcdispatch` methods — their
         # frozen Unions won't dispatch on us.
@@ -668,8 +671,13 @@ end
 
 # Property Accesors
 
-objc_propertynames(::Type{<:Object}) = Symbol[]
-objc_propertynames(::Nothing) = Symbol[]
+# Default `objc_propertynames` walks the ObjC parent chain. `@objcproperties`
+# emits a more specific method per class that merges the class's own list
+# with the parent's; without that method, this fallback ensures a child
+# wrapper still surfaces its ancestor's properties.
+@inline objc_propertynames(::Type{T}) where {T<:Object} =
+    objc_propertynames(objc_parent(T))
+@inline objc_propertynames(::Nothing) = Symbol[]
 
 # Generic property accessors used by `@objcproperties`-generated dispatch.
 # When a class has no override, walk the Objective-C parent chain. The chain
@@ -859,7 +867,8 @@ macro objcproperties(typ, ex)
         isempty(args) || propertyerror("too many positional arguments")
     end
 
-    # generate Base.propertynames definition
+    # Generate the per-class `objc_propertynames`. `Base.propertynames` is
+    # already emitted by `@objcwrapper` and routes through this method.
     propertynames_ex = quote
         function $ObjectiveC.objc_propertynames(::Type{$(esc(typ))})
             properties = [$(map(QuoteNode, collect(propertynames))...)]
@@ -868,9 +877,6 @@ macro objcproperties(typ, ex)
                 properties = union(properties, $ObjectiveC.objc_propertynames(parent))
             end
             return properties
-        end
-        function Base.propertynames(::$(esc(typ)))
-            $ObjectiveC.objc_propertynames($(esc(typ)))
         end
     end
 

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -429,7 +429,8 @@ macro objcwrapper(ex...)
         name, super = def.args
     elseif def isa Symbol
         name = def
-        super = :Object
+        # qualified so `@objcwrapper Foo` works even without `using ObjectiveC`
+        super = :($ObjectiveC.Object)
     else
         wrappererror()
     end

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -63,7 +63,13 @@ end
 
 # Resolve `KindOf{P}` to its dispatch type — `P` alone if no subclasses are
 # wrapped, or `Union{P, descendants...}` otherwise.
+#
+# When `P` is abstract (e.g. `Object` itself), every wrapper is already
+# `<: P` in Julia's type system, so `Union{P, descendants...}` simplifies to
+# `P` and a `KindOf{P}` dispatch is just `::P`. Short-circuit so we don't
+# walk the method table or register a stale-Union watcher.
 function objc_kindof_type(P::Type)
+    isabstracttype(P) && return P
     sub = objc_subtree(P)
     length(sub) == 1 ? sub[1] : Union{sub...}
 end
@@ -653,13 +659,14 @@ macro objcdispatch(ex)
     end
 
     # Register this call site under every parent T so a later `@objcwrapper
-    # Sub <: T` can warn that the Union is now stale.
+    # Sub <: T` can warn that the Union is now stale. Skip abstract Ts: their
+    # Union collapses to `T` and Julia's `<:` already covers any subclass.
     src_file = String(__source__.file)
     src_line = Int(__source__.line)
     fname_q = QuoteNode(fname isa Symbol ? fname : Symbol(fname))
     register_calls = [
         :( $ObjectiveC.register_objcdispatch_site!($P, $fname_q, $src_file, $src_line) )
-        for P in unique(parent_types)
+        for P in unique(parent_types) if !isabstracttype(P)
     ]
 
     esc(quote

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -1,4 +1,70 @@
-export @objc, @objcwrapper, @objcproperties, @objcblock
+export @objc, @objcwrapper, @objcproperties, @objcblock, @objcdispatch
+export KindOf, inherits_from
+
+
+# Class hierarchy as a runtime trait
+#
+# Each `@objcwrapper Foo <: Bar` declaration emits `objc_parent(::Type{Foo}) = Bar`.
+# `inherits_from(T, S)` walks the chain; the recursion is `@inline` and folds to a
+# compile-time constant whenever T and S are statically known.
+
+objc_parent(::Type{Object}) = nothing
+objc_parent(::Type{<:Object}) = nothing   # fallback for classes declared without a `<: parent` clause
+
+inherits_from(::Type, ::Type) = false
+@inline function inherits_from(::Type{T}, ::Type{S}) where {T<:Object, S<:Object}
+    T === S && return true
+    P = objc_parent(T)
+    P === nothing && return false
+    inherits_from(P, S)
+end
+
+
+# Covariant wrapper for polymorphic methods on non-leaf classes — modeled on
+# Objective-C's `__kindof T *` type qualifier.
+#
+# `KindOf{T}` wraps the pointer of any object that
+# `inherits_from(typeof(obj), T)`. Methods written on `KindOf{T}` form the
+# canonical implementation, and a top-level dispatcher (emitted by
+# `@objcdispatch`) routes raw `Object` arguments through the `inherits_from`
+# trait. Because `KindOf{T}` only stores a primitive `id{T}` it is itself a
+# bitstype (when T is fixed); the wrap is a register move.
+struct KindOf{T<:Object}
+    ptr::id{T}
+    KindOf{T}(ptr::id{T}) where {T<:Object} = new{T}(ptr)
+end
+# Wrap an existing object as `KindOf{T}`. The forwarder emitted by
+# `@objcdispatch` already gates on `inherits_from`, but direct construction
+# would otherwise silently bitcast — re-check here so the type invariant
+# holds for every constructed value.
+@inline function KindOf{T}(obj::Object) where {T<:Object}
+    inherits_from(typeof(obj), T) ||
+        throw(ArgumentError("$(typeof(obj)) does not inherit from $T"))
+    KindOf{T}(Base.bitcast(id{T}, getfield(obj, :ptr)))
+end
+
+# Allow KindOf{T} to satisfy ccall sigs that take `id{T}` or `id{Object}`.
+Base.cconvert(::Type{<:id}, x::KindOf) = x
+@inline Base.unsafe_convert(::Type{id{T}}, x::KindOf{T}) where {T<:Object} = x.ptr
+@inline Base.unsafe_convert(::Type{id{U}}, x::KindOf{T}) where {U<:Object, T<:Object} =
+    Base.bitcast(id{U}, x.ptr)
+Base.pointer(x::KindOf{T}) where {T<:Object} = x.ptr
+
+# Property access on KindOf{T} routes through T's `objc_getproperty` chain —
+# same as `obj::T` would. The inheritance walk via `objc_parent` delivers
+# parent-class properties transparently.
+@inline Base.getproperty(x::KindOf{T}, field::Symbol) where {T<:Object} =
+    objc_getproperty(T, x, field)
+@inline Base.setproperty!(x::KindOf{T}, field::Symbol, value) where {T<:Object} =
+    objc_setproperty!(T, x, field, value)
+Base.propertynames(::KindOf{T}) where {T<:Object} = objc_propertynames(T)
+
+
+# Tie `id{U}` → `id{T}` conversions to `inherits_from` whenever both are
+# `<:Object`. Forward-declared in primitives.jl; the actual check lives here so
+# it can use `inherits_from`.
+compatible_id_types(::Type{T}, ::Type{U}) where {T<:Object, U<:Object} =
+    inherits_from(U, T)
 
 
 # Method Calling
@@ -263,25 +329,28 @@ wrappererror(msg) = error("""ObjectiveC wrapper: $msg
 """
     @objcwrapper [kwargs] name [<: super]
 
-Helper macro to define a set of Julia classes for wrapping Objective-C pointers.
+Define a Julia struct that wraps an Objective-C object pointer.
 
-Because Objective-C supports multilevel inheritance, we cannot directly translate its
-class model to Julia's. Instead, we define an abstract class `name` that implements the
-requested hierarchy (extending `super`, which defaults to `Object`), along with an instance
-class `$(name)Instance` that wraps an Objective-C pointer.
+Each declaration generates a concrete `struct name <: Object` (or
+`mutable struct` when `immutable=false`) holding a single `ptr::id{name}` field.
+The Objective-C class hierarchy is recorded by emitting
+`objc_parent(::Type{name}) = super` (defaulting to `Object`), which the
+recursive `inherits_from` trait uses to model `<:`-style relationships at the
+ObjC layer without forcing a Julia abstract type for each non-leaf class.
 
-The split into two classes should not be visible to the end user. Methods should only ever
-use the `name` class, both for dispatch purposes and when constructing objects.
+Methods can be written directly on the concrete struct (e.g.
+`length(s::NSString) = ...`); polymorphic methods over an inheritance chain
+should be expressed via [`@objcdispatch`](@ref).
 
-In addition to this boilerplate, `@objcwrapper`'s code generation can be customized through
-keyword arguments:
+Keyword arguments:
 
-  * `immutable`: if `true` (default), define the instance class as an immutable. Should be
-    disabled when you want to use finalizers.
-  * `availability`: A `PlatformAvailability` object that represents the availability of the object.
-  * `comparison`: if `true` (default `false`), define `==` and `hash` methods for the
-    wrapper class. This should not be necessary when using an immutable struct, in which
-    case the default `==` and `hash` methods are sufficient.
+  * `immutable`: if `true` (default), define the wrapper as an immutable struct.
+    Should be disabled when you want to attach finalizers (e.g., for objects
+    that need explicit `release`).
+  * `availability`: a `PlatformAvailability` describing the OS/version
+    availability of the class.
+  * `comparison`: if `true` (default `false`), define `==` and `hash` for the
+    wrapper class. Mostly useful for `mutable struct` wrappers.
 """
 macro objcwrapper(ex...)
     def = ex[end]
@@ -318,47 +387,55 @@ macro objcwrapper(ex...)
         name, super = def.args
     elseif def isa Symbol
         name = def
-        super = Object
+        super = :Object
     else
         wrappererror()
     end
 
-    # generate type hierarchy
-    ex = quote
-        abstract type $name <: $super end
-    end
-
-    # generate the instance class
-    instance = Symbol(name, "Instance")
-    ex = if immutable
+    # define the concrete struct. The constructor checks availability and rejects nil.
+    structdef = if immutable
         quote
-            $(ex.args...)
-            struct $instance <: $name
-                ptr::id{$name}
+            struct $name <: $ObjectiveC.Object
+                ptr::$ObjectiveC.id{$name}
+                function $name(ptr::$ObjectiveC.id)
+                    @static if !$ObjectiveC.is_available($availability)
+                        throw($UnavailableError(Symbol($(QuoteNode(name))), $availability))
+                    end
+                    ptr == $ObjectiveC.nil && throw(UndefRefError())
+                    new(ptr)
+                end
             end
         end
     else
         quote
-            $(ex.args...)
-            mutable struct $instance <: $name
-                ptr::id{$name}
+            mutable struct $name <: $ObjectiveC.Object
+                ptr::$ObjectiveC.id{$name}
+                function $name(ptr::$ObjectiveC.id)
+                    @static if !$ObjectiveC.is_available($availability)
+                        throw($UnavailableError(Symbol($(QuoteNode(name))), $availability))
+                    end
+                    ptr == $ObjectiveC.nil && throw(UndefRefError())
+                    new(ptr)
+                end
             end
         end
     end
 
-    # add essential methods
     ex = quote
-        $(ex.args...)
+        $(structdef.args...)
 
-        # add a pseudo constructor to the abstract type that also checks for nil pointers.
-        function $name(ptr::id)
-            @static if !ObjectiveC.is_available($availability)
-                throw($UnavailableError(Symbol($name), $availability))
-            end
+        # record the immediate ObjC parent for `inherits_from`.
+        $ObjectiveC.objc_parent(::Type{$name}) = $super
 
-            ptr == nil && throw(UndefRefError())
-            $instance(ptr)
-        end
+        # default property forwarders. `@objcproperties` may override
+        # `objc_getproperty`/`objc_setproperty!` per class to install
+        # autoproperty branches; without that, the chain walks straight to the
+        # parent via `objc_parent`, all the way up to `Object` where it falls
+        # back to `getfield`/`setfield!`.
+        Base.getproperty(object::$name, field::Symbol) =
+            $ObjectiveC.objc_getproperty($name, object, field)
+        Base.setproperty!(object::$name, field::Symbol, value::Any) =
+            $ObjectiveC.objc_setproperty!($name, object, field, value)
     end
 
     # add optional methods
@@ -366,15 +443,17 @@ macro objcwrapper(ex...)
         ex = quote
             $(ex.args...)
 
-            Base.:(==)(a::$instance, b::$instance) = pointer(a) == pointer(b)
-            Base.hash(obj::$instance, h::UInt) = hash(pointer(obj), h)
+            Base.:(==)(a::$name, b::$name) = pointer(a) == pointer(b)
+            Base.hash(obj::$name, h::UInt) = hash(pointer(obj), h)
         end
     end
 
     esc(ex)
 end
 
-Base.pointer(obj::Object) = obj.ptr
+# Use `getfield` to bypass any user-defined `getproperty` (e.g., from
+# `@objcproperties`) when accessing the pointer slot.
+Base.pointer(obj::Object) = getfield(obj, :ptr)
 
 # when passing a single object, we automatically convert it to an object pointer
 Base.unsafe_convert(T::Type{<:id}, obj::Object) = convert(T, pointer(obj))
@@ -391,9 +470,216 @@ Base.unsafe_convert(T::Type{<:id}, arr::idArray) =
     reinterpret(T, pointer(arr.ids))
 
 
+# `@objcdispatch f(arg::KindOf{T}, ...)::ret begin ... end`
+#
+# Emits:
+#   1. The canonical implementation on `KindOf{T}` (the macro body).
+#   2. A top-level method on `Object` that routes through `inherits_from`,
+#      so calling `f(::SomeSubclassOfT)` repacks into `KindOf{T}` and
+#      forwards. Because `inherits_from(::Type{Sub}, ::Type{T})` const-folds
+#      to `true` when both are known statically, the indirection compiles to
+#      a register move plus a direct call.
+"""
+    @objcdispatch f(arg::KindOf{T}, more...)::ret begin
+        # canonical body, may use `arg` as a typed `id{T}` via @objc
+    end
+
+Define a polymorphic Objective-C method on the class `T`. The canonical body
+runs on a [`KindOf{T}`](@ref) wrapper (modeled on ObjC's `__kindof T *`);
+ObjectiveC.jl additionally generates a top-level method that accepts any
+`Object` and routes through `inherits_from(typeof(obj), T)` — so `f(sub)`
+works for any subclass of `T`, with the dispatch resolved at compile time
+when `typeof(sub)` is known statically.
+
+Use this in place of `f(::T) = ...` whenever `T` has subclasses *and* you
+want `f` to dispatch over them. For methods on classes with no subclasses
+(the common case), write a regular Julia method on the concrete struct.
+
+Note that the canonical body sees `arg` typed as `KindOf{T}` — the concrete
+subclass is not visible. When you need `typeof(arg)` inside the body
+(e.g. to reconstruct the return wrapper), write a regular method on `::Object`
+with an explicit `inherits_from` guard instead.
+
+# Limitation: forwarder signatures must be distinct
+
+The auto-emitted `Object` forwarder erases `T` to `::Object`. If two
+`@objcdispatch` methods on the same generic function have the same name,
+arity, and types in the remaining argument slots, their forwarders will
+have identical signatures and silently overwrite one another. Disambiguate
+by typing the trailing arguments differently, or — when the colliding
+methods are semantically distinct — write a single manual method on
+`::Object` that branches on `inherits_from`.
+"""
+macro objcdispatch(ex)
+    # Accept `@objcdispatch @inline function ... end` style by unwrapping
+    # leading macro decorators (e.g. `@inline`, `@noinline`).
+    decorators = Any[]
+    while Meta.isexpr(ex, :macrocall)
+        # Drop the LineNumberNode in macrocalls (args[2])
+        push!(decorators, ex.args[1])
+        ex = ex.args[end]
+    end
+
+    Meta.isexpr(ex, :function) || Meta.isexpr(ex, :(=)) ||
+        wrappererror("@objcdispatch expects a function definition")
+
+    sig = ex.args[1]
+    body = ex.args[2]
+
+    # Peel off `f(...)::ret`
+    rettype = nothing
+    if Meta.isexpr(sig, :(::))
+        rettype = sig.args[2]
+        sig = sig.args[1]
+    end
+
+    # Peel off `where {T...}`
+    whereparams = Any[]
+    while Meta.isexpr(sig, :where)
+        append!(whereparams, sig.args[2:end])
+        sig = sig.args[1]
+    end
+
+    Meta.isexpr(sig, :call) || wrappererror("@objcdispatch expects a function-call signature")
+
+    fname = sig.args[1]
+    rawargs = sig.args[2:end]
+
+    # Separate kwargs (Expr(:parameters, ...)) from positional args.
+    kwparams = nothing
+    args = Any[]
+    for a in rawargs
+        if Meta.isexpr(a, :parameters)
+            kwparams = a
+        else
+            push!(args, a)
+        end
+    end
+    isempty(args) && wrappererror("@objcdispatch needs at least one positional argument typed `KindOf{T}`")
+
+    # Recognize `KindOf{T}` and any qualified form ending in `KindOf{T}`
+    # (e.g. `ObjectiveC.KindOf{T}`, `OC.KindOf{T}`).
+    function is_kindof_type(e)
+        Meta.isexpr(e, :curly) || return false
+        head = e.args[1]
+        head === :KindOf && return true
+        Meta.isexpr(head, :.) && head.args[2] === QuoteNode(:KindOf) && return true
+        return false
+    end
+
+    # Locate the `KindOf{T}` argument; remember the type parameter T.
+    iface_idx = nothing
+    iface_T = nothing
+    for (i, a) in enumerate(args)
+        if Meta.isexpr(a, :(::)) && is_kindof_type(a.args[2])
+            iface_idx = i
+            iface_T = a.args[2].args[2]
+            break
+        end
+    end
+    iface_idx === nothing &&
+        wrappererror("@objcdispatch needs one argument typed `KindOf{T}`")
+
+    function argname(a)
+        if Meta.isexpr(a, :(::))
+            length(a.args) == 1 && return gensym(:_)   # anonymous typed slot
+            return a.args[1]
+        end
+        a
+    end
+    fwd_args = Any[argname(a) for a in args]
+
+    # Build the obj-dispatcher signature by swapping `::KindOf{T}` for
+    # `::Object`. For anonymous typed slots (`::T`), restore the gensym name
+    # we synthesized in `fwd_args` so the forwarder body can reference it.
+    obj_args = map(enumerate(args)) do (i, a)
+        if i == iface_idx
+            :( $(fwd_args[i])::$ObjectiveC.Object )
+        elseif Meta.isexpr(a, :(::)) && length(a.args) == 1
+            :( $(fwd_args[i])::$(a.args[1]) )
+        else
+            a
+        end
+    end
+
+    # Reconstruct the canonical signature (with decorators, kwargs, where, ret).
+    function rebuild_sig(call_args)
+        new_sig = Expr(:call, fname, call_args...)
+        if kwparams !== nothing
+            insert!(new_sig.args, 2, kwparams)
+        end
+        for tp in whereparams
+            new_sig = Expr(:where, new_sig, tp)
+        end
+        rettype === nothing ? new_sig : Expr(:(::), new_sig, rettype)
+    end
+
+    canonical = Expr(:function, rebuild_sig(args), body)
+    # Apply decorators back (innermost first, since they were pushed outer-first).
+    for dec in reverse(decorators)
+        canonical = Expr(:macrocall, dec, LineNumberNode(0), canonical)
+    end
+
+    iface_arg_name = fwd_args[iface_idx]
+    wrapped = :( $ObjectiveC.KindOf{$iface_T}($iface_arg_name) )
+    fwd_call_args = copy(fwd_args)
+    fwd_call_args[iface_idx] = wrapped
+
+    fwd_call = Expr(:call, fname, fwd_call_args...)
+    # Forward kwargs by splat
+    if kwparams !== nothing
+        # call site: f(args...; kwargs...) — collect kw names from kwparams
+        kw_names = Any[]
+        for kw in kwparams.args
+            if Meta.isexpr(kw, :kw)
+                push!(kw_names, kw.args[1])
+            elseif Meta.isexpr(kw, :(::))
+                push!(kw_names, kw.args[1])
+            else
+                push!(kw_names, kw)
+            end
+        end
+        # build `f(args...; k1=k1, k2=k2)`
+        fwd_kwparams = Expr(:parameters, [Expr(:kw, n isa Symbol ? n : n.args[1],
+                                                n isa Symbol ? n : n.args[1]) for n in kw_names]...)
+        insert!(fwd_call.args, 2, fwd_kwparams)
+    end
+
+    obj_body = quote
+        $ObjectiveC.inherits_from(typeof($iface_arg_name), $iface_T) ||
+            throw(MethodError($fname, ($(fwd_args...),)))
+        $fwd_call
+    end
+
+    obj_fn = Expr(:function, rebuild_sig(obj_args), obj_body)
+    # Reuse decorators on the dispatcher too (e.g., @inline forwarder)
+    for dec in reverse(decorators)
+        obj_fn = Expr(:macrocall, dec, LineNumberNode(0), obj_fn)
+    end
+
+    esc(quote
+        Core.@__doc__ $canonical
+        $obj_fn
+    end)
+end
+
+
 # Property Accesors
 
-objc_propertynames(obj::Type{<:Object}) = Symbol[]
+objc_propertynames(::Type{<:Object}) = Symbol[]
+objc_propertynames(::Nothing) = Symbol[]
+
+# Generic property accessors used by `@objcproperties`-generated dispatch.
+# When a class has no override, walk the Objective-C parent chain. The chain
+# bottoms out at `nothing` (the sentinel returned by `objc_parent(::Type{Object})`),
+# at which point we fall back to the default `getfield`/`setfield!`.
+@inline objc_getproperty(::Nothing, obj, field::Symbol) = getfield(obj, field)
+@inline objc_getproperty(::Type{T}, obj, field::Symbol) where {T<:Object} =
+    objc_getproperty(objc_parent(T), obj, field)
+@inline objc_setproperty!(::Nothing, obj, field::Symbol, value) =
+    setfield!(obj, field, value)
+@inline objc_setproperty!(::Type{T}, obj, field::Symbol, value) where {T<:Object} =
+    objc_setproperty!(objc_parent(T), obj, field, value)
 
 propertyerror(s::String) = error("""Objective-C property declaration: $s.
                                     Refer to the @objcproperties docstring for more details.""")
@@ -575,8 +861,9 @@ macro objcproperties(typ, ex)
     propertynames_ex = quote
         function $ObjectiveC.objc_propertynames(::Type{$(esc(typ))})
             properties = [$(map(QuoteNode, collect(propertynames))...)]
-            if supertype($(esc(typ))) != Any
-                properties = union(properties, $ObjectiveC.objc_propertynames(supertype($(esc(typ)))))
+            parent = $ObjectiveC.objc_parent($(esc(typ)))
+            if parent !== nothing
+                properties = union(properties, $ObjectiveC.objc_propertynames(parent))
             end
             return properties
         end
@@ -585,7 +872,17 @@ macro objcproperties(typ, ex)
         end
     end
 
-    # generate `Base.getproperty` definition, if needed
+    # generate `Base.getproperty` / `objc_getproperty` definitions.
+    # We define `objc_getproperty(::Type{T}, obj, field)` rather than
+    # `Base.getproperty` directly, so the ObjC parent chain can be walked at
+    # runtime via `objc_parent` (replacing the old `invoke(getproperty,
+    # supertype(T), ...)` chain). The wrapper `Base.getproperty(obj::T, field) =
+    # objc_getproperty(T, obj, field)` is the user-facing entry. Julia
+    # specializes `objc_getproperty` per concrete `obj` type at the call site
+    # so type-stability is preserved through the chain.
+    #
+    # `obj` is intentionally left untyped — the same method must also serve
+    # `KindOf{T}` wrappers, which are not `<:Object`.
     getproperties_ex = quote end
     if !isempty(read_properties)
         current = nothing
@@ -601,20 +898,18 @@ macro objcproperties(typ, ex)
             end
         end
 
-        # finally, call our parent's `getproperty`
-        final = :(@inline invoke(getproperty,
-                                 Tuple{supertype($(esc(typ))), Symbol},
-                                 object, field))
+        # fall through to the ObjC parent chain
+        final = :(return $ObjectiveC.objc_getproperty(
+                    $ObjectiveC.objc_parent($(esc(typ))), object, field))
         push!(current.args, final)
         getproperties_ex = quote
-            # XXX: force const-prop on field, without inlining everything?
-            function Base.getproperty(object::$(esc(typ)), field::Symbol)
+            function $ObjectiveC.objc_getproperty(::Type{$(esc(typ))}, object, field::Symbol)
                 $getproperties_ex
             end
         end
     end
 
-    # generate `Base.setproperty!` definition, if needed
+    # generate `Base.setproperty!` / `objc_setproperty!` definitions
     setproperties_ex = quote end
     if !isempty(write_properties)
         current = nothing
@@ -630,14 +925,13 @@ macro objcproperties(typ, ex)
             end
         end
 
-        # finally, call our parent's `setproperty!`
-        final = :(@inline invoke(setproperty!,
-                                 Tuple{supertype($(esc(typ))), Symbol, Any},
-                                 object, field, value))
+        # fall through to the ObjC parent chain
+        final = :(return $ObjectiveC.objc_setproperty!(
+                    $ObjectiveC.objc_parent($(esc(typ))), object, field, value))
         push!(current.args, final)
         setproperties_ex = quote
-            # XXX: force const-prop on field, without inlining everything?
-            function Base.setproperty!(object::$(esc(typ)), field::Symbol, value::Any)
+            function $ObjectiveC.objc_setproperty!(::Type{$(esc(typ))}, object,
+                                                    field::Symbol, value::Any)
                 $setproperties_ex
             end
         end

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -1,5 +1,5 @@
 export @objc, @objcwrapper, @objcproperties, @objcblock, @objcdispatch
-export KindOf, inherits_from, classkind, ObjectKind
+export KindOf
 
 
 # Kind hierarchy: a parallel abstract-type lattice mirroring the ObjC class

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -1,118 +1,44 @@
 export @objc, @objcwrapper, @objcproperties, @objcblock, @objcdispatch
-export KindOf, inherits_from
+export KindOf, inherits_from, classkind, ObjectKind
 
 
-# Class hierarchy as a runtime trait
+# Kind hierarchy: a parallel abstract-type lattice mirroring the ObjC class
+# graph, used purely for trait dispatch.
 #
-# Each `@objcwrapper Foo <: Bar` declaration emits `objc_parent(::Type{Foo}) = Bar`.
-# `inherits_from(T, S)` walks the chain; the recursion is `@inline` and folds to a
-# compile-time constant whenever T and S are statically known.
+# Each `@objcwrapper Foo <: Bar` emits `abstract type FooKind <: BarKind end`
+# alongside the concrete `struct Foo <: Object`. The concrete types stay flat
+# (so `Vector{Foo}` is unboxed), while `classkind(::Type{Foo}) = FooKind`
+# lets `@objcdispatch` dispatch through the Kind lattice via Julia's native
+# multiple dispatch. There's no registration, no late-subclass warning, and
+# no closed-vs-open distinction — Julia's type lattice does all the work.
+#
+# `ObjectKind` is the lattice root; non-ObjC types fall through to `Nothing`
+# so `inherits_from` returns false without a special case.
+abstract type ObjectKind end
+classkind(::Type) = Nothing
+classkind(::Type{Object}) = ObjectKind
 
+inherits_from(T::Type, S::Type) = classkind(T) <: classkind(S)
+
+
+# `objc_parent` is kept for the `@objcproperties`-generated property dispatch
+# chain (which walks `objc_parent(T)` to inherit properties from ObjC
+# ancestors). The Kind lattice handles polymorphic *method* dispatch.
 objc_parent(::Type{Object}) = nothing
-objc_parent(::Type{<:Object}) = nothing   # fallback for classes declared without a `<: parent` clause
-
-inherits_from(::Type, ::Type) = false
-@inline function inherits_from(::Type{T}, ::Type{S}) where {T<:Object, S<:Object}
-    T === S && return true
-    P = objc_parent(T)
-    P === nothing && return false
-    inherits_from(P, S)
-end
+objc_parent(::Type{<:Object}) = nothing
 
 
-# `KindOf{T}` is a *marker* type used exclusively in `@objcdispatch` argument
-# slots — it has no values. The macro substitutes it at expansion time with
-# `Union{T, descendants(T)...}`, where descendants are enumerated by walking
-# the `objc_parent` method table. The result is a regular Julia method on a
-# concrete Union; dispatch goes through native multiple-dispatch with no
-# wrapper, no forwarder, and no runtime `inherits_from` check.
-#
-# Modeled on ObjC's `__kindof T *` type qualifier (covariant subclass pointer).
+# `KindOf{T}` is a parse-time marker recognized by `@objcdispatch` in
+# argument positions. The struct itself is never instantiated — the macro
+# rewrites each `KindOf{T}` slot into trait dispatch on `Type{<:classkind(T)}`.
+# Modeled on Objective-C's `__kindof T *` type qualifier.
 struct KindOf{T<:Object} end
 
-# Walk the `objc_parent` method table to enumerate every type that
-# `inherits_from(T, P)`, including P itself. Used by `@objcdispatch` to expand
-# `KindOf{P}` into a Union at macro-expansion time.
-function objc_subtree(P::Type)
-    P <: Object || return Type[P]
-    result = Type[P]
-    queue = Type[P]
-    seen = Set{Type}((P,))
-    while !isempty(queue)
-        current = popfirst!(queue)
-        for m in methods(objc_parent)
-            sig = m.sig
-            sig isa DataType && length(sig.parameters) >= 2 || continue
-            tp = sig.parameters[2]
-            tp isa DataType && tp <: Type || continue
-            length(tp.parameters) == 1 || continue
-            Sub = tp.parameters[1]
-            Sub isa Type && Sub <: Object || continue
-            Sub === Object && continue  # the `Type{Object}` and `Type{<:Object}` fallbacks
-            Sub === current && continue  # skip self (would re-enqueue)
-            objc_parent(Sub) === current || continue
-            if !(Sub in seen)
-                push!(seen, Sub)
-                push!(result, Sub)
-                push!(queue, Sub)
-            end
-        end
-    end
-    return result
-end
 
-# Resolve `KindOf{P}` to its dispatch type — `P` alone if no subclasses are
-# wrapped, or `Union{P, descendants...}` otherwise.
-#
-# When `P` is abstract (e.g. `Object` itself), every wrapper is already
-# `<: P` in Julia's type system, so `Union{P, descendants...}` simplifies to
-# `P` and a `KindOf{P}` dispatch is just `::P`. Short-circuit so we don't
-# walk the method table or register a stale-Union watcher.
-function objc_kindof_type(P::Type)
-    isabstracttype(P) && return P
-    sub = objc_subtree(P)
-    length(sub) == 1 ? sub[1] : Union{sub...}
-end
-
-
-# Per-parent registry of `@objcdispatch` call sites. Populated as a side
-# effect of each `@objcdispatch` expansion (the macro emits a top-level
-# `register_objcdispatch_site!`). Consulted by `@objcwrapper Sub <: Parent`
-# to warn when a subclass is declared after methods on its ancestor —
-# such methods will not dispatch on `Sub`, because their Union was frozen
-# at the time `@objcdispatch` was processed.
-const objcdispatch_sites = IdDict{Type, Vector{NamedTuple{(:name, :file, :line), Tuple{String, String, Int}}}}()
-
-function register_objcdispatch_site!(P::Type, name::AbstractString, file::AbstractString, line::Integer)
-    sites = get!(() -> NamedTuple{(:name, :file, :line), Tuple{String, String, Int}}[], objcdispatch_sites, P)
-    entry = (name=String(name), file=String(file), line=Int(line))
-    entry in sites || push!(sites, entry)
-    return
-end
-
-function warn_late_subclass(child::Type, parent::Type)
-    p = parent
-    while p isa Type && p <: Object
-        if haskey(objcdispatch_sites, p)
-            for site in objcdispatch_sites[p]
-                @warn """`@objcwrapper $child <: $parent` declared after `@objcdispatch \
-                         $(site.name)(::KindOf{$p}, …)` at $(site.file):$(site.line). \
-                         The existing method will not dispatch on $child; move the \
-                         `@objcwrapper` above the `@objcdispatch`."""
-            end
-        end
-        p === Object && break
-        p = objc_parent(p)
-    end
-    return
-end
-
-
-# Tie `id{U}` → `id{T}` conversions to `inherits_from` whenever both are
-# `<:Object`. Forward-declared in primitives.jl; the actual check lives here so
-# it can use `inherits_from`.
+# Tie `id{U}` → `id{T}` conversions to the Kind lattice. Forward-declared in
+# primitives.jl.
 compatible_id_types(::Type{T}, ::Type{U}) where {T<:Object, U<:Object} =
-    inherits_from(U, T)
+    classkind(U) <: classkind(T)
 
 
 # Method Calling
@@ -470,10 +396,20 @@ macro objcwrapper(ex...)
         end
     end
 
+    # Emit the parallel abstract `${name}Kind <: classkind(super)` for trait
+    # dispatch via `@objcdispatch`. `classkind(super)` is resolved at the
+    # declaration site, so the super's Kind type must already exist (same
+    # ordering rule as the concrete struct's `<:Object`).
+    kindname = Symbol(name, "Kind")
+
     ex = quote
         $(structdef.args...)
 
-        # record the immediate ObjC parent for `inherits_from`.
+        # parallel Kind type, used by `@objcdispatch` for subclass dispatch.
+        abstract type $kindname <: $ObjectiveC.classkind($super) end
+        $ObjectiveC.classkind(::Type{$name}) = $kindname
+
+        # record the immediate ObjC parent for the property-dispatch chain.
         $ObjectiveC.objc_parent(::Type{$name}) = $super
 
         # default property forwarders. `@objcproperties` may override
@@ -488,10 +424,6 @@ macro objcwrapper(ex...)
         Base.setproperty!(object::$name, field::Symbol, value::Any) =
             $ObjectiveC.objc_setproperty!($name, object, field, value)
         Base.propertynames(::$name) = $ObjectiveC.objc_propertynames($name)
-
-        # Warn if any ancestor already has `@objcdispatch` methods — their
-        # frozen Unions won't dispatch on us.
-        $ObjectiveC.warn_late_subclass($name, $super)
     end
 
     # add optional methods
@@ -527,55 +459,40 @@ Base.unsafe_convert(T::Type{<:id}, arr::idArray) =
 
 
 """
-    @objcdispatch [open=false] f(arg::KindOf{T}, more...)::ret begin
+    @objcdispatch f(arg::KindOf{T}, more...)::ret begin
         # body
     end
 
-Define a polymorphic Objective-C method on the class `T`. Two dispatch
-modes are supported, picked via the `open` keyword argument:
+Define an Objective-C method polymorphic over `T` and every wrapped subclass
+of `T` (including subclasses declared in downstream modules).
 
-  * `open=false` (default) — **closed-world dispatch.** The macro substitutes
-    `KindOf{T}` at expansion time with `Union{T, descendants...}`, where
-    descendants come from walking the `objc_parent` method table. The result
-    is a regular Julia method on a concrete Union, dispatched natively —
-    `typeof(arg)` inside the body is the concrete subclass. The substitution
-    is frozen; subclasses declared *after* the method via `@objcwrapper
-    Sub <: T` will not flow through it, and a warning fires from the
-    subsequent `@objcwrapper` pointing at the affected call site. Use this
-    mode for methods scoped to a sub-hierarchy fully owned by one module.
+The macro lowers each `KindOf{T}` slot to trait dispatch on the parallel
+**Kind lattice** emitted by `@objcwrapper`. For a signature
+`f(x::KindOf{T}, more...)` it generates two methods:
 
-  * `open=true` — **open-world dispatch.** The macro substitutes `KindOf{T}`
-    with the abstract apex `Object`, so any current or future wrapper
-    matches dispatch, and prepends a runtime guard
-    `inherits_from(typeof(arg), T) || throw(MethodError(f, (...,)))` to the
-    method body. The call site is not registered (no late-subclass warning).
-    Use this mode for methods that should remain available to any wrapper
-    declared by downstream packages — for example, foundation primitives
-    like `retain`/`release`/`==` that semantically apply to every
-    `KindOf{NSObject}` regardless of which package introduces the subclass.
+  * a body method `f(::Type{<:classkind(T)}, x, more...) = …`, dispatched
+    on the Kind of the actual argument's class;
+  * an entry forwarder `f(x::Object, more...) = f(classkind(typeof(x)), x, more...)`,
+    which is identical across all `@objcdispatch` sites for the same `f`
+    (Julia will simply redefine it, harmlessly).
 
-Both modes use the same `KindOf{T}` spelling at the call site. Modeled on
-Objective-C's `__kindof T *` type qualifier.
+Multiple `KindOf{T}` slots are each lowered the same way; the trait
+dispatch args are prepended to the body in order. Subclasses declared
+*later* (in this or any downstream module) automatically participate
+because their `SubKind <: ParentKind` slots into the lattice that
+Julia's native dispatch already walks — there is no Union to freeze, no
+registration, and no late-subclass warning needed.
+
+`typeof(x)` inside the body returns the concrete wrapper (e.g.
+`MPSCommandBuffer`), since the entry forwarder leaves the argument's
+runtime type intact. When the argument's static type is known at the call
+site, the trait dispatch folds through both methods to a direct call.
 """
 macro objcdispatch(ex...)
     decl = ex[end]
-    kwargs = ex[1:end-1]
-
-    # Parse keyword arguments. Only `open=Bool` is supported.
-    open = false
-    for kw in kwargs
-        if kw isa Expr && kw.head == :(=)
-            key, value = kw.args
-            if key == :open
-                value isa Bool || wrappererror("`open` keyword argument must be a literal boolean")
-                open = value
-            else
-                wrappererror("unrecognized keyword argument: $key")
-            end
-        else
-            wrappererror("invalid keyword argument: $kw")
-        end
-    end
+    isempty(ex[1:end-1]) ||
+        wrappererror("@objcdispatch no longer accepts keyword arguments; \
+                      drop `open=true` (every `@objcdispatch` is now open by construction)")
 
     ex = decl
     # Accept `@objcdispatch @inline function ... end` style by unwrapping
@@ -637,8 +554,6 @@ macro objcdispatch(ex...)
     end
 
     # Locate every `KindOf{T}` argument and remember each type parameter T.
-    # All slots are substituted independently — `f(::KindOf{A}, ::KindOf{B})`
-    # produces a method with both slots expanded to their respective Unions.
     # The arg may be named (`x::T`, length 2) or anonymous (`::T`, length 1).
     kindof_slots = Tuple{Int, Any}[]
     for (i, a) in enumerate(args)
@@ -650,10 +565,8 @@ macro objcdispatch(ex...)
     isempty(kindof_slots) &&
         wrappererror("@objcdispatch needs at least one argument typed `KindOf{T}`")
 
-    # Ensure every positional arg has a name we can reference, both for the
-    # substituted signature and (under `open=true`) for the `MethodError`
-    # tuple. Anonymous-typed args (`::T`) get a gensym; the names are stable
-    # across both passes below.
+    # Name every positional arg (gensym anonymous ones) so we can pass them
+    # through to the body method from the entry forwarder.
     arg_names = Symbol[]
     for a in args
         if Meta.isexpr(a, :(::))
@@ -665,14 +578,11 @@ macro objcdispatch(ex...)
         end
     end
 
-    # Resolve every T in the user's module. With `open=false`, substitute
-    # `KindOf{T}` with the closed-world `Union{T, descendants...}`. With
-    # `open=true`, substitute with the apex `Object` so any wrapper matches
-    # dispatch — the runtime guard emitted below enforces the actual T.
-    new_args = copy(args)
-    parent_types = Type[]
-    open_guards = Tuple{Symbol, Type}[]
-    for (idx, T_expr) in kindof_slots
+    # Sanity-check each KindOf{T}: T must resolve to a `<: Object` at
+    # macroexpand time. We don't otherwise use T at expansion time — the
+    # generated `Type{<:classkind(T)}` resolves it again at function-def
+    # time in the user's module.
+    for (_, T_expr) in kindof_slots
         P = try
             Core.eval(__module__, T_expr)
         catch err
@@ -680,78 +590,117 @@ macro objcdispatch(ex...)
         end
         P isa Type && P <: Object ||
             wrappererror("@objcdispatch type parameter `$T_expr` must resolve to a subtype of `Object`, got $P")
-        push!(parent_types, P)
+    end
 
-        name = arg_names[idx]
-        if open
-            new_args[idx] = :( $name::$ObjectiveC.Object )
-            push!(open_guards, (name, P))
+    # Build the body method's signature: each `KindOf{T}` arg is `::Object`
+    # in-place (named with arg_names[idx]), and a `::Type{<:classkind(T)}`
+    # trait-dispatch arg is prepended (one per KindOf slot, in order).
+    body_args = Any[]
+    for (i, a) in enumerate(args)
+        if Meta.isexpr(a, :(::)) && is_kindof_type(a.args[end])
+            push!(body_args, :( $(arg_names[i])::$ObjectiveC.Object ))
+        elseif Meta.isexpr(a, :(::)) && length(a.args) == 1
+            # anonymous-typed positional arg: promote to a named one so
+            # the entry forwarder can pass it through.
+            push!(body_args, :( $(arg_names[i])::$(a.args[1]) ))
         else
-            new_args[idx] = :( $name::$(objc_kindof_type(P)) )
+            push!(body_args, a)
         end
     end
-
-    # Re-emit anonymous-typed positional args with their gensym name so the
-    # `MethodError` tuple under `open=true` can reference every arg.
-    if open
-        for (i, a) in enumerate(args)
-            if Meta.isexpr(a, :(::)) && length(a.args) == 1 && new_args[i] === a
-                new_args[i] = :( $(arg_names[i])::$(a.args[1]) )
-            end
-        end
-        # Prepend the runtime guard for each `KindOf{T}` arg. The first
-        # mismatching arg throws a `MethodError` carrying every positional
-        # arg, mirroring the message Julia would produce had dispatch failed.
-        guard = Expr(:block)
-        args_tuple = Expr(:tuple, arg_names...)
-        for (name, P) in open_guards
-            push!(guard.args, :(
-                $ObjectiveC.inherits_from(typeof($name), $P) ||
-                    throw(MethodError($fname, $args_tuple))
-            ))
-        end
-        body = Expr(:block, guard, body)
-    end
-
-    # Reconstruct the signature (with kwargs, where, ret).
-    new_sig = Expr(:call, fname, new_args...)
+    kind_args = Any[
+        :( ::Type{<:$ObjectiveC.classkind($T_expr)} )
+        for (_, T_expr) in kindof_slots
+    ]
+    body_sig = Expr(:call, fname, kind_args..., body_args...)
     if kwparams !== nothing
-        insert!(new_sig.args, 2, kwparams)
+        insert!(body_sig.args, 2, kwparams)
     end
     for tp in whereparams
-        new_sig = Expr(:where, new_sig, tp)
+        body_sig = Expr(:where, body_sig, tp)
     end
     if rettype !== nothing
-        new_sig = Expr(:(::), new_sig, rettype)
+        body_sig = Expr(:(::), body_sig, rettype)
     end
-
-    method_def = Expr(:function, new_sig, body)
+    body_def = Expr(:function, body_sig, body)
     for dec in reverse(decorators)
-        # Re-emit the original macrocall with the new function body in the
-        # trailing slot, preserving every other arg (LineNumberNode, kwargs).
-        method_def = Expr(:macrocall, dec.args[1:end-1]..., method_def)
+        body_def = Expr(:macrocall, dec.args[1:end-1]..., body_def)
     end
 
-    # Register this call site under every parent T so a later `@objcwrapper
-    # Sub <: T` can warn that the Union is now stale. Skip abstract Ts (their
-    # Union collapses to `T`) and skip every site under `open=true` (the
-    # method already dispatches via `::Object` and re-checks at runtime, so
-    # there is no stale Union to warn about).
-    src_file = String(__source__.file)
-    src_line = Int(__source__.line)
-    # Store the function name as a String so qualified spellings
-    # (`Base.show`, `MyMod.foo`) round-trip into the late-subclass warning
-    # faithfully — `Symbol(Expr)` would mangle them via `string`.
-    fname_str = string(fname)
-    register_calls = open ? Expr[] : [
-        :( $ObjectiveC.register_objcdispatch_site!($P, $fname_str, $src_file, $src_line) )
-        for P in unique(parent_types) if !isabstracttype(P)
+    # Build the entry forwarder's signature: same positional args as the
+    # user's signature, but `KindOf{T}` slots become `::Object`. Anonymous
+    # positional args get the same gensym name so we can pass them through.
+    # The entry's body forwards to the trait-dispatched method, prepending
+    # `classkind(typeof(x))` for each KindOf arg.
+    entry_args = Any[]
+    for (i, a) in enumerate(args)
+        if Meta.isexpr(a, :(::)) && is_kindof_type(a.args[end])
+            push!(entry_args, :( $(arg_names[i])::$ObjectiveC.Object ))
+        elseif Meta.isexpr(a, :(::)) && length(a.args) == 1
+            push!(entry_args, :( $(arg_names[i])::$(a.args[1]) ))
+        else
+            push!(entry_args, a)
+        end
+    end
+    classkind_calls = Any[
+        :( $ObjectiveC.classkind(typeof($(arg_names[idx]))) )
+        for (idx, _) in kindof_slots
     ]
+    fwd_call = Expr(:call, fname, classkind_calls..., arg_names...)
+    entry_sig = Expr(:call, fname, entry_args...)
+    if kwparams !== nothing
+        # Collect kwargs as `; kwargs__...` on the entry, splat them through
+        # to the body method on the forwarded call.
+        kwsym = gensym(:kw)
+        insert!(entry_sig.args, 2, Expr(:parameters, Expr(:..., kwsym)))
+        insert!(fwd_call.args, 2, Expr(:parameters, Expr(:..., kwsym)))
+    end
+    for tp in whereparams
+        entry_sig = Expr(:where, entry_sig, tp)
+    end
+    # No rettype on the entry — it just forwards; the body method carries
+    # the annotation if any.
+    entry_def = Expr(:(=), entry_sig, fwd_call)
+
+    # Two `@objcdispatch` sites for the same function with disjoint
+    # `KindOf{T}` roots but otherwise identical args produce the same entry
+    # signature. Emitting it twice is "method overwriting", which Julia 1.12
+    # rejects during precompile. Guard the entry with a top-level check
+    # that asks `which` for the most-specific method on this exact arg
+    # tuple, and skip emission only when that method's signature already
+    # matches ours exactly. A `hasmethod` check would be too loose — for
+    # `Base.:(==)` it would return true via `==(::Any, ::Any)` and we'd
+    # never emit our entry. The body method's signature always differs
+    # across sites — it carries the trait-dispatch `Type{<:…Kind}` args —
+    # so it never needs guarding.
+    entry_arg_types = Any[
+        Meta.isexpr(a, :(::)) ? a.args[end] : :Any
+        for a in entry_args
+    ]
+    entry_sig_tuple = Expr(:curly, :Tuple, entry_arg_types...)
+    for tp in whereparams
+        entry_sig_tuple = Expr(:where, entry_sig_tuple, tp)
+    end
 
     esc(quote
-        Core.@__doc__ $method_def
-        $(register_calls...)
+        Core.@__doc__ $body_def
+        if !$ObjectiveC.has_exact_method($fname, $entry_sig_tuple)
+            $entry_def
+        end
     end)
+end
+
+# True iff `f` has a method whose signature is *exactly* `Tuple{typeof(f),
+# argtypes.parameters...}` — used by `@objcdispatch` to decide whether the
+# entry forwarder is already in place. `hasmethod` would be too loose
+# (`hasmethod(==, Tuple{Object, Object})` is true via `==(::Any, ::Any)`).
+function has_exact_method(@nospecialize(f), @nospecialize(argtypes::Type))
+    sig = Tuple{typeof(f), Base.unwrap_unionall(argtypes).parameters...}
+    m = try
+        which(f, argtypes)
+    catch
+        return false
+    end
+    m.sig === sig || m.sig == sig
 end
 
 

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -647,12 +647,17 @@ macro objcmethod(ex...)
     end)
 end
 
-# True iff `f` has a method whose signature is *exactly* `Tuple{typeof(f),
-# argtypes.parameters...}` — used by `@objcmethod` to decide whether the
-# entry forwarder is already in place. `hasmethod` would be too loose
-# (`hasmethod(==, Tuple{Object, Object})` is true via `==(::Any, ::Any)`).
+# True iff `f` has a method whose signature is *exactly*
+# `Tuple{Core.Typeof(f), argtypes.parameters...}` — used by `@objcmethod` to
+# decide whether the entry forwarder is already in place. `hasmethod` would be
+# too loose (`hasmethod(==, Tuple{Object, Object})` is true via `==(::Any,
+# ::Any)`).  `Core.Typeof` gives `Type{T}` when `f` is itself a type and
+# `typeof(f)` otherwise, matching how the method table keys constructors —
+# without it, two `@objcmethod` overloads of a constructor would both fail
+# this check and both emit the entry forwarder, which Julia 1.12 rejects as
+# method overwriting during precompilation.
 function has_exact_method(@nospecialize(f), @nospecialize(argtypes::Type))
-    sig = Tuple{typeof(f), Base.unwrap_unionall(argtypes).parameters...}
+    sig = Tuple{Core.Typeof(f), Base.unwrap_unionall(argtypes).parameters...}
     m = try
         which(f, argtypes)
     catch

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -506,41 +506,19 @@ macro objcdispatch(ex...)
         ex = ex.args[end]
     end
 
-    Meta.isexpr(ex, :function) || Meta.isexpr(ex, :(=)) ||
-        wrappererror("@objcdispatch expects a function definition")
-
-    sig = ex.args[1]
-    body = ex.args[2]
-
-    # Peel off `f(...)::ret`
-    rettype = nothing
-    if Meta.isexpr(sig, :(::))
-        rettype = sig.args[2]
-        sig = sig.args[1]
+    # Parse the function definition. `splitdef` handles long-form (`function
+    # f(...) end`), short-form (`f(...) = ...`), where clauses, return-type
+    # annotations, kwargs, default values, varargs, etc. uniformly into a
+    # `Dict{Symbol,Any}` we can mutate and rebuild via `combinedef`.
+    def = try
+        splitdef(ex)
+    catch err
+        wrappererror("@objcdispatch expects a function definition ($err)")
     end
-
-    # Peel off `where {T...}`
-    whereparams = Any[]
-    while Meta.isexpr(sig, :where)
-        append!(whereparams, sig.args[2:end])
-        sig = sig.args[1]
-    end
-
-    Meta.isexpr(sig, :call) || wrappererror("@objcdispatch expects a function-call signature")
-
-    fname = sig.args[1]
-    rawargs = sig.args[2:end]
-
-    # Separate kwargs (Expr(:parameters, ...)) from positional args.
-    kwparams = nothing
-    args = Any[]
-    for a in rawargs
-        if Meta.isexpr(a, :parameters)
-            kwparams = a
-        else
-            push!(args, a)
-        end
-    end
+    args        = get(def, :args, Any[])::Vector
+    kwargs      = get(def, :kwargs, Any[])::Vector
+    whereparams = get(def, :whereparams, Any[])::Vector
+    fname       = def[:name]
     isempty(args) && wrappererror("@objcdispatch needs at least one positional argument typed `KindOf{T}`")
 
     # Recognize `KindOf{T}` and any qualified form ending in `KindOf{T}`
@@ -553,8 +531,8 @@ macro objcdispatch(ex...)
         return false
     end
 
-    # Locate every `KindOf{T}` argument and remember each type parameter T.
-    # The arg may be named (`x::T`, length 2) or anonymous (`::T`, length 1).
+    # Locate every `KindOf{T}` slot (allowed forms: `x::KindOf{T}`,
+    # `::KindOf{T}`). Remember the type parameter for each.
     kindof_slots = Tuple{Int, Any}[]
     for (i, a) in enumerate(args)
         Meta.isexpr(a, :(::)) || continue
@@ -565,8 +543,8 @@ macro objcdispatch(ex...)
     isempty(kindof_slots) &&
         wrappererror("@objcdispatch needs at least one argument typed `KindOf{T}`")
 
-    # Name every positional arg (gensym anonymous ones) so we can pass them
-    # through to the body method from the entry forwarder.
+    # Name every positional arg (gensym anonymous ones) so the entry
+    # forwarder can pass them through to the body method.
     arg_names = Symbol[]
     for a in args
         if Meta.isexpr(a, :(::))
@@ -579,7 +557,7 @@ macro objcdispatch(ex...)
     end
 
     # Sanity-check each KindOf{T}: T must resolve to a `<: Object` at
-    # macroexpand time. We don't otherwise use T at expansion time — the
+    # macroexpand time. We don't otherwise use T at expansion time; the
     # generated `Type{<:classkind(T)}` resolves it again at function-def
     # time in the user's module.
     for (_, T_expr) in kindof_slots
@@ -592,74 +570,54 @@ macro objcdispatch(ex...)
             wrappererror("@objcdispatch type parameter `$T_expr` must resolve to a subtype of `Object`, got $P")
     end
 
-    # Build the body method's signature: each `KindOf{T}` arg is `::Object`
-    # in-place (named with arg_names[idx]), and a `::Type{<:classkind(T)}`
-    # trait-dispatch arg is prepended (one per KindOf slot, in order).
-    body_args = Any[]
-    for (i, a) in enumerate(args)
+    # Helper: rewrite the user's positional args into the entry-side shape —
+    # each `KindOf{T}` slot becomes `::Object`, anonymous-typed args are
+    # named so the forwarder can reference them.
+    function entry_arg(i, a)
         if Meta.isexpr(a, :(::)) && is_kindof_type(a.args[end])
-            push!(body_args, :( $(arg_names[i])::$ObjectiveC.Object ))
+            :( $(arg_names[i])::$ObjectiveC.Object )
         elseif Meta.isexpr(a, :(::)) && length(a.args) == 1
-            # anonymous-typed positional arg: promote to a named one so
-            # the entry forwarder can pass it through.
-            push!(body_args, :( $(arg_names[i])::$(a.args[1]) ))
+            :( $(arg_names[i])::$(a.args[1]) )
         else
-            push!(body_args, a)
+            a
         end
     end
-    kind_args = Any[
-        :( ::Type{<:$ObjectiveC.classkind($T_expr)} )
-        for (_, T_expr) in kindof_slots
-    ]
-    body_sig = Expr(:call, fname, kind_args..., body_args...)
-    if kwparams !== nothing
-        insert!(body_sig.args, 2, kwparams)
-    end
-    for tp in whereparams
-        body_sig = Expr(:where, body_sig, tp)
-    end
-    if rettype !== nothing
-        body_sig = Expr(:(::), body_sig, rettype)
-    end
-    body_def = Expr(:function, body_sig, body)
+    rewritten_args = Any[entry_arg(i, a) for (i, a) in enumerate(args)]
+
+    # Body method: trait-dispatch args (`::Type{<:classkind(T)}`) prepended
+    # to the user's positional args (with KindOf slots rewritten to
+    # `::Object`). `combinedef` rebuilds the full def from the dict.
+    body_def = combinedef(merge(def, Dict(
+        :args => vcat(
+            Any[:( ::Type{<:$ObjectiveC.classkind($T_expr)} ) for (_, T_expr) in kindof_slots],
+            rewritten_args,
+        ),
+    )))
     for dec in reverse(decorators)
         body_def = Expr(:macrocall, dec.args[1:end-1]..., body_def)
     end
 
-    # Build the entry forwarder's signature: same positional args as the
-    # user's signature, but `KindOf{T}` slots become `::Object`. Anonymous
-    # positional args get the same gensym name so we can pass them through.
-    # The entry's body forwards to the trait-dispatched method, prepending
-    # `classkind(typeof(x))` for each KindOf arg.
-    entry_args = Any[]
-    for (i, a) in enumerate(args)
-        if Meta.isexpr(a, :(::)) && is_kindof_type(a.args[end])
-            push!(entry_args, :( $(arg_names[i])::$ObjectiveC.Object ))
-        elseif Meta.isexpr(a, :(::)) && length(a.args) == 1
-            push!(entry_args, :( $(arg_names[i])::$(a.args[1]) ))
-        else
-            push!(entry_args, a)
-        end
+    # Entry forwarder: same positional args as the user wrote (with KindOf
+    # slots rewritten), forwards to the body method with
+    # `classkind(typeof(x))` prepended for each KindOf arg. Strip the rtype
+    # — the body carries it if any. Kwargs are forwarded by splat.
+    kwsym = isempty(kwargs) ? nothing : gensym(:kw)
+    fwd_args = vcat(
+        Any[:( $ObjectiveC.classkind(typeof($(arg_names[idx]))) ) for (idx, _) in kindof_slots],
+        Any[arg_names...],
+    )
+    fwd_call = if kwsym === nothing
+        Expr(:call, fname, fwd_args...)
+    else
+        Expr(:call, fname, Expr(:parameters, Expr(:..., kwsym)), fwd_args...)
     end
-    classkind_calls = Any[
-        :( $ObjectiveC.classkind(typeof($(arg_names[idx]))) )
-        for (idx, _) in kindof_slots
-    ]
-    fwd_call = Expr(:call, fname, classkind_calls..., arg_names...)
-    entry_sig = Expr(:call, fname, entry_args...)
-    if kwparams !== nothing
-        # Collect kwargs as `; kwargs__...` on the entry, splat them through
-        # to the body method on the forwarded call.
-        kwsym = gensym(:kw)
-        insert!(entry_sig.args, 2, Expr(:parameters, Expr(:..., kwsym)))
-        insert!(fwd_call.args, 2, Expr(:parameters, Expr(:..., kwsym)))
-    end
-    for tp in whereparams
-        entry_sig = Expr(:where, entry_sig, tp)
-    end
-    # No rettype on the entry — it just forwards; the body method carries
-    # the annotation if any.
-    entry_def = Expr(:(=), entry_sig, fwd_call)
+    entry_def = combinedef(Dict(
+        :name => fname,
+        :args => rewritten_args,
+        :kwargs => kwsym === nothing ? Any[] : Any[Expr(:..., kwsym)],
+        :whereparams => whereparams,
+        :body => fwd_call,
+    ))
 
     # Two `@objcdispatch` sites for the same function with disjoint
     # `KindOf{T}` roots but otherwise identical args produce the same entry
@@ -670,11 +628,11 @@ macro objcdispatch(ex...)
     # matches ours exactly. A `hasmethod` check would be too loose — for
     # `Base.:(==)` it would return true via `==(::Any, ::Any)` and we'd
     # never emit our entry. The body method's signature always differs
-    # across sites — it carries the trait-dispatch `Type{<:…Kind}` args —
-    # so it never needs guarding.
+    # across sites (it carries the trait-dispatch `Type{<:…Kind}` args), so
+    # it never needs guarding.
     entry_arg_types = Any[
         Meta.isexpr(a, :(::)) ? a.args[end] : :Any
-        for a in entry_args
+        for a in rewritten_args
     ]
     entry_sig_tuple = Expr(:curly, :Tuple, entry_arg_types...)
     for tp in whereparams

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -20,44 +20,87 @@ inherits_from(::Type, ::Type) = false
 end
 
 
-# Covariant wrapper for polymorphic methods on non-leaf classes — modeled on
-# Objective-C's `__kindof T *` type qualifier.
+# `KindOf{T}` is a *marker* type used exclusively in `@objcdispatch` argument
+# slots — it has no values. The macro substitutes it at expansion time with
+# `Union{T, descendants(T)...}`, where descendants are enumerated by walking
+# the `objc_parent` method table. The result is a regular Julia method on a
+# concrete Union; dispatch goes through native multiple-dispatch with no
+# wrapper, no forwarder, and no runtime `inherits_from` check.
 #
-# `KindOf{T}` wraps the pointer of any object that
-# `inherits_from(typeof(obj), T)`. Methods written on `KindOf{T}` form the
-# canonical implementation, and a top-level dispatcher (emitted by
-# `@objcdispatch`) routes raw `Object` arguments through the `inherits_from`
-# trait. Because `KindOf{T}` only stores a primitive `id{T}` it is itself a
-# bitstype (when T is fixed); the wrap is a register move.
-struct KindOf{T<:Object}
-    ptr::id{T}
-    KindOf{T}(ptr::id{T}) where {T<:Object} = new{T}(ptr)
-end
-# Wrap an existing object as `KindOf{T}`. The forwarder emitted by
-# `@objcdispatch` already gates on `inherits_from`, but direct construction
-# would otherwise silently bitcast — re-check here so the type invariant
-# holds for every constructed value.
-@inline function KindOf{T}(obj::Object) where {T<:Object}
-    inherits_from(typeof(obj), T) ||
-        throw(ArgumentError("$(typeof(obj)) does not inherit from $T"))
-    KindOf{T}(Base.bitcast(id{T}, getfield(obj, :ptr)))
+# Modeled on ObjC's `__kindof T *` type qualifier (covariant subclass pointer).
+struct KindOf{T<:Object} end
+
+# Walk the `objc_parent` method table to enumerate every type that
+# `inherits_from(T, P)`, including P itself. Used by `@objcdispatch` to expand
+# `KindOf{P}` into a Union at macro-expansion time.
+function objc_subtree(P::Type)
+    P <: Object || return Type[P]
+    result = Type[P]
+    queue = Type[P]
+    seen = Set{Type}((P,))
+    while !isempty(queue)
+        current = popfirst!(queue)
+        for m in methods(objc_parent)
+            sig = m.sig
+            sig isa DataType && length(sig.parameters) >= 2 || continue
+            tp = sig.parameters[2]
+            tp isa DataType && tp <: Type || continue
+            length(tp.parameters) == 1 || continue
+            Sub = tp.parameters[1]
+            Sub isa Type && Sub <: Object || continue
+            Sub === Object && continue  # the `Type{Object}` and `Type{<:Object}` fallbacks
+            Sub === current && continue  # skip self (would re-enqueue)
+            objc_parent(Sub) === current || continue
+            if !(Sub in seen)
+                push!(seen, Sub)
+                push!(result, Sub)
+                push!(queue, Sub)
+            end
+        end
+    end
+    return result
 end
 
-# Allow KindOf{T} to satisfy ccall sigs that take `id{T}` or `id{Object}`.
-Base.cconvert(::Type{<:id}, x::KindOf) = x
-@inline Base.unsafe_convert(::Type{id{T}}, x::KindOf{T}) where {T<:Object} = x.ptr
-@inline Base.unsafe_convert(::Type{id{U}}, x::KindOf{T}) where {U<:Object, T<:Object} =
-    Base.bitcast(id{U}, x.ptr)
-Base.pointer(x::KindOf{T}) where {T<:Object} = x.ptr
+# Resolve `KindOf{P}` to its dispatch type — `P` alone if no subclasses are
+# wrapped, or `Union{P, descendants...}` otherwise.
+function objc_kindof_type(P::Type)
+    sub = objc_subtree(P)
+    length(sub) == 1 ? sub[1] : Union{sub...}
+end
 
-# Property access on KindOf{T} routes through T's `objc_getproperty` chain —
-# same as `obj::T` would. The inheritance walk via `objc_parent` delivers
-# parent-class properties transparently.
-@inline Base.getproperty(x::KindOf{T}, field::Symbol) where {T<:Object} =
-    objc_getproperty(T, x, field)
-@inline Base.setproperty!(x::KindOf{T}, field::Symbol, value) where {T<:Object} =
-    objc_setproperty!(T, x, field, value)
-Base.propertynames(::KindOf{T}) where {T<:Object} = objc_propertynames(T)
+
+# Per-parent registry of `@objcdispatch` call sites. Populated as a side
+# effect of each `@objcdispatch` expansion (the macro emits a top-level
+# `register_objcdispatch_site!`). Consulted by `@objcwrapper Sub <: Parent`
+# to warn when a subclass is declared after methods on its ancestor —
+# such methods will not dispatch on `Sub`, because their Union was frozen
+# at the time `@objcdispatch` was processed.
+const objcdispatch_sites = IdDict{Type, Vector{NamedTuple{(:name, :file, :line), Tuple{Symbol, String, Int}}}}()
+
+function register_objcdispatch_site!(P::Type, name::Symbol, file::AbstractString, line::Integer)
+    sites = get!(() -> NamedTuple{(:name, :file, :line), Tuple{Symbol, String, Int}}[], objcdispatch_sites, P)
+    entry = (name=name, file=String(file), line=Int(line))
+    entry in sites || push!(sites, entry)
+    return
+end
+
+function warn_late_subclass(child::Type, parent::Type)
+    p = parent
+    while p isa Type && p <: Object
+        if haskey(objcdispatch_sites, p)
+            for site in objcdispatch_sites[p]
+                @warn """`@objcwrapper $child <: $parent` declared after `@objcdispatch \
+                         $(site.name)(::KindOf{$p}, …)` at $(site.file):$(site.line). \
+                         The existing method will not dispatch on $child; redeclare the \
+                         `@objcdispatch` after the `@objcwrapper`, or move the wrapper \
+                         above the methods."""
+            end
+        end
+        p === Object && break
+        p = objc_parent(p)
+    end
+    return
+end
 
 
 # Tie `id{U}` → `id{T}` conversions to `inherits_from` whenever both are
@@ -436,6 +479,10 @@ macro objcwrapper(ex...)
             $ObjectiveC.objc_getproperty($name, object, field)
         Base.setproperty!(object::$name, field::Symbol, value::Any) =
             $ObjectiveC.objc_setproperty!($name, object, field, value)
+
+        # Warn if any ancestor already has `@objcdispatch` methods — their
+        # frozen Unions won't dispatch on us.
+        $ObjectiveC.warn_late_subclass($name, $super)
     end
 
     # add optional methods
@@ -470,45 +517,25 @@ Base.unsafe_convert(T::Type{<:id}, arr::idArray) =
     reinterpret(T, pointer(arr.ids))
 
 
-# `@objcdispatch f(arg::KindOf{T}, ...)::ret begin ... end`
-#
-# Emits:
-#   1. The canonical implementation on `KindOf{T}` (the macro body).
-#   2. A top-level method on `Object` that routes through `inherits_from`,
-#      so calling `f(::SomeSubclassOfT)` repacks into `KindOf{T}` and
-#      forwards. Because `inherits_from(::Type{Sub}, ::Type{T})` const-folds
-#      to `true` when both are known statically, the indirection compiles to
-#      a register move plus a direct call.
 """
     @objcdispatch f(arg::KindOf{T}, more...)::ret begin
-        # canonical body, may use `arg` as a typed `id{T}` via @objc
+        # body — `arg` is typed as `Union{T, descendants(T)...}`
     end
 
-Define a polymorphic Objective-C method on the class `T`. The canonical body
-runs on a [`KindOf{T}`](@ref) wrapper (modeled on ObjC's `__kindof T *`);
-ObjectiveC.jl additionally generates a top-level method that accepts any
-`Object` and routes through `inherits_from(typeof(obj), T)` — so `f(sub)`
-works for any subclass of `T`, with the dispatch resolved at compile time
-when `typeof(sub)` is known statically.
+Define a polymorphic Objective-C method on the class `T` and every currently
+wrapped subclass of `T`. The macro substitutes `KindOf{T}` at expansion time
+with `Union{T, descendants...}`, where descendants come from walking the
+`objc_parent` method table. The result is a regular Julia method on a concrete
+Union, dispatched natively — `typeof(arg)` inside the body is the concrete
+subclass.
 
-Use this in place of `f(::T) = ...` whenever `T` has subclasses *and* you
-want `f` to dispatch over them. For methods on classes with no subclasses
-(the common case), write a regular Julia method on the concrete struct.
+The substitution is frozen at macro expansion. **Wrappers must be declared
+before any `@objcdispatch` method that should dispatch on them.** Declaring a
+subclass via `@objcwrapper Sub <: Parent` *after* an `@objcdispatch` on
+`KindOf{Parent}` will fire a warning; `Sub` won't flow through the existing
+method until you redeclare it.
 
-Note that the canonical body sees `arg` typed as `KindOf{T}` — the concrete
-subclass is not visible. When you need `typeof(arg)` inside the body
-(e.g. to reconstruct the return wrapper), write a regular method on `::Object`
-with an explicit `inherits_from` guard instead.
-
-# Limitation: forwarder signatures must be distinct
-
-The auto-emitted `Object` forwarder erases `T` to `::Object`. If two
-`@objcdispatch` methods on the same generic function have the same name,
-arity, and types in the remaining argument slots, their forwarders will
-have identical signatures and silently overwrite one another. Disambiguate
-by typing the trailing arguments differently, or — when the colliding
-methods are semantically distinct — write a single manual method on
-`::Object` that branches on `inherits_from`.
+Modeled on Objective-C's `__kindof T *` type qualifier.
 """
 macro objcdispatch(ex)
     # Accept `@objcdispatch @inline function ... end` style by unwrapping
@@ -580,86 +607,55 @@ macro objcdispatch(ex)
     iface_idx === nothing &&
         wrappererror("@objcdispatch needs one argument typed `KindOf{T}`")
 
-    function argname(a)
-        if Meta.isexpr(a, :(::))
-            length(a.args) == 1 && return gensym(:_)   # anonymous typed slot
-            return a.args[1]
-        end
-        a
+    # Resolve T (the `KindOf{T}` parameter) in the user's module so we can
+    # compute the dispatch Union at macroexpand time.
+    P = try
+        Core.eval(__module__, iface_T)
+    catch err
+        wrappererror("@objcdispatch could not resolve `$iface_T` (must be a wrapped class declared earlier): $err")
     end
-    fwd_args = Any[argname(a) for a in args]
+    P isa Type && P <: Object ||
+        wrappererror("@objcdispatch type parameter `$iface_T` must resolve to a subtype of `Object`, got $P")
 
-    # Build the obj-dispatcher signature by swapping `::KindOf{T}` for
-    # `::Object`. For anonymous typed slots (`::T`), restore the gensym name
-    # we synthesized in `fwd_args` so the forwarder body can reference it.
-    obj_args = map(enumerate(args)) do (i, a)
-        if i == iface_idx
-            :( $(fwd_args[i])::$ObjectiveC.Object )
-        elseif Meta.isexpr(a, :(::)) && length(a.args) == 1
-            :( $(fwd_args[i])::$(a.args[1]) )
-        else
-            a
-        end
+    union_type = objc_kindof_type(P)
+
+    # Substitute `KindOf{P}` with the Union at the matched arg slot.
+    new_args = copy(args)
+    iface_a = args[iface_idx]
+    iface_arg_name = if Meta.isexpr(iface_a, :(::)) && length(iface_a.args) == 2
+        iface_a.args[1]
+    else
+        gensym(:_)
     end
+    new_args[iface_idx] = :( $iface_arg_name::$union_type )
 
-    # Reconstruct the canonical signature (with decorators, kwargs, where, ret).
-    function rebuild_sig(call_args)
-        new_sig = Expr(:call, fname, call_args...)
-        if kwparams !== nothing
-            insert!(new_sig.args, 2, kwparams)
-        end
-        for tp in whereparams
-            new_sig = Expr(:where, new_sig, tp)
-        end
-        rettype === nothing ? new_sig : Expr(:(::), new_sig, rettype)
-    end
-
-    canonical = Expr(:function, rebuild_sig(args), body)
-    # Apply decorators back (innermost first, since they were pushed outer-first).
-    for dec in reverse(decorators)
-        canonical = Expr(:macrocall, dec, LineNumberNode(0), canonical)
-    end
-
-    iface_arg_name = fwd_args[iface_idx]
-    wrapped = :( $ObjectiveC.KindOf{$iface_T}($iface_arg_name) )
-    fwd_call_args = copy(fwd_args)
-    fwd_call_args[iface_idx] = wrapped
-
-    fwd_call = Expr(:call, fname, fwd_call_args...)
-    # Forward kwargs by splat
+    # Reconstruct the signature (with kwargs, where, ret).
+    new_sig = Expr(:call, fname, new_args...)
     if kwparams !== nothing
-        # call site: f(args...; kwargs...) — collect kw names from kwparams
-        kw_names = Any[]
-        for kw in kwparams.args
-            if Meta.isexpr(kw, :kw)
-                push!(kw_names, kw.args[1])
-            elseif Meta.isexpr(kw, :(::))
-                push!(kw_names, kw.args[1])
-            else
-                push!(kw_names, kw)
-            end
-        end
-        # build `f(args...; k1=k1, k2=k2)`
-        fwd_kwparams = Expr(:parameters, [Expr(:kw, n isa Symbol ? n : n.args[1],
-                                                n isa Symbol ? n : n.args[1]) for n in kw_names]...)
-        insert!(fwd_call.args, 2, fwd_kwparams)
+        insert!(new_sig.args, 2, kwparams)
+    end
+    for tp in whereparams
+        new_sig = Expr(:where, new_sig, tp)
+    end
+    if rettype !== nothing
+        new_sig = Expr(:(::), new_sig, rettype)
     end
 
-    obj_body = quote
-        $ObjectiveC.inherits_from(typeof($iface_arg_name), $iface_T) ||
-            throw(MethodError($fname, ($(fwd_args...),)))
-        $fwd_call
-    end
-
-    obj_fn = Expr(:function, rebuild_sig(obj_args), obj_body)
-    # Reuse decorators on the dispatcher too (e.g., @inline forwarder)
+    method_def = Expr(:function, new_sig, body)
     for dec in reverse(decorators)
-        obj_fn = Expr(:macrocall, dec, LineNumberNode(0), obj_fn)
+        method_def = Expr(:macrocall, dec, LineNumberNode(0), method_def)
     end
+
+    # Register this call site so a later `@objcwrapper Sub <: P` can warn that
+    # the Union is now stale.
+    src_file = String(__source__.file)
+    src_line = Int(__source__.line)
+    fname_q = QuoteNode(fname isa Symbol ? fname : Symbol(fname))
+    register_call = :( $ObjectiveC.register_objcdispatch_site!($P, $fname_q, $src_file, $src_line) )
 
     esc(quote
-        Core.@__doc__ $canonical
-        $obj_fn
+        Core.@__doc__ $method_def
+        $register_call
     end)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -288,23 +288,39 @@ end
     end
 end
 
+# `@objcdispatch` methods declared at top level: they should dispatch on
+# subclasses declared later, even from outside the current testset.
+@objcdispatch open_len_kind(s::KindOf{TestNSString})::Int =
+    Int(@objc [s::id{TestNSString} length]::Culong)
+@objcdispatch open_pair(a::KindOf{TestNSString}, b::KindOf{TestNSOperationQueue}) =
+    (typeof(a), typeof(b))
+# Subclass declared *after* the methods above — Kind-lattice dispatch
+# means it just works, with no warning, no registry, and no Union to
+# refreeze.
+@objcwrapper TestLateSub <: TestNSString
+
 @testset "inheritance / @objcdispatch" begin
     # The existing @objcproperties fixture gives us a two-level hierarchy:
     #   TestNSMutableString <: TestNSString <: Object
     # plus a sibling TestNSOperationQueue <: Object.
 
-    # inherits_from: walks the parent chain
+    # inherits_from: walks the Kind lattice
     @test inherits_from(TestNSString, TestNSString)
     @test inherits_from(TestNSMutableString, TestNSString)
     @test inherits_from(TestNSMutableString, Object)
     @test !inherits_from(TestNSString, TestNSMutableString)
     @test !inherits_from(TestNSOperationQueue, TestNSString)
     @test !inherits_from(TestNSString, TestNSOperationQueue)
-    # non-Object types short-circuit
+    # non-Object types fall through to `classkind = Nothing`
     @test !inherits_from(Int, TestNSString)
     @test !inherits_from(TestNSString, Int)
 
-    # id{Sub} ↔ id{Parent} conversion follows inherits_from
+    # the Kind lattice mirrors the ObjC parent chain
+    @test classkind(TestNSMutableString) <: classkind(TestNSString)
+    @test classkind(TestNSString) <: classkind(Object)
+    @test !(classkind(TestNSOperationQueue) <: classkind(TestNSString))
+
+    # id{Sub} ↔ id{Parent} conversion follows the Kind lattice
     raw = @objc [NSMutableString stringWithUTF8String:"abcd"::Ptr{UInt8}]::id{TestNSMutableString}
     @test raw isa id{TestNSMutableString}
     @test convert(id{TestNSString}, raw) isa id{TestNSString}
@@ -315,32 +331,28 @@ end
     @test_throws ArgumentError convert(id{TestNSMutableString}, parent_ptr)
     @test reinterpret(id{TestNSMutableString}, parent_ptr) isa id{TestNSMutableString}
 
-    # objc_subtree enumerates parent + descendants via the objc_parent method table
-    sub = ObjectiveC.objc_subtree(TestNSString)
-    @test TestNSString in sub
-    @test TestNSMutableString in sub
-    @test !(TestNSOperationQueue in sub)
-    @test ObjectiveC.objc_subtree(TestNSMutableString) == [TestNSMutableString]
-
-    # @objcdispatch expands KindOf{Parent} into Union{Parent, descendants...}
-    @objcdispatch testlen(s::KindOf{TestNSString})::Int =
-        Int(@objc [s::id{TestNSString} length]::Culong)
-
     mut = TestNSMutableString(raw)
     str = TestNSString(@objc [NSString stringWithUTF8String:"xyz"::Ptr{UInt8}]::id{TestNSString})
-    @test testlen(mut) == 4   # subclass dispatch
-    @test testlen(str) == 3   # exact-type dispatch
-
-    # non-conforming Object → MethodError (Julia's normal Union dispatch)
     queue = TestNSOperationQueue(@objc [NSOperationQueue new]::id{TestNSOperationQueue})
-    @test_throws MethodError testlen(queue)
+
+    # @objcdispatch dispatches on the Kind lattice — parent and every
+    # subclass route to the same body.
+    @test open_len_kind(mut) == 4    # subclass
+    @test open_len_kind(str) == 3    # exact type
+    # …including subclasses declared *after* the @objcdispatch site.
+    late = TestLateSub(@objc [NSString stringWithUTF8String:"xyz"::Ptr{UInt8}]::id{TestLateSub})
+    @test open_len_kind(late) == 3
+
+    # non-conforming class → MethodError on the body method.
+    @test_throws MethodError open_len_kind(queue)
 
     # qualified `KindOf{T}` is recognized by @objcdispatch
     @objcdispatch testlen_qualified(s::ObjectiveC.KindOf{TestNSString})::Int =
         Int(@objc [s::id{TestNSString} length]::Culong)
     @test testlen_qualified(mut) == 4
 
-    # the body sees the concrete subclass (no wrapper to erase it)
+    # the body sees the concrete subclass — `typeof(x)` resolves through
+    # the entry forwarder.
     @objcdispatch concretetype(s::KindOf{TestNSString}) = typeof(s)
     @test concretetype(mut) === TestNSMutableString
     @test concretetype(str) === TestNSString
@@ -349,22 +361,18 @@ end
     @test mut.length == 4
     @test unsafe_string(mut.UTF8String) == "abcd"
 
-    # late-subclass warning: declaring a subclass after `@objcdispatch` warns
-    @test_warn r"declared after `@objcdispatch testlen" begin
-        @eval @objcwrapper TestLateSub <: TestNSString
-    end
-
-    # multiple `KindOf{T}` slots are all substituted (issue: previously only
-    # the first slot was rewritten, leaving the rest as the empty marker).
+    # multiple `KindOf{T}` slots: every slot is independently lowered into
+    # trait dispatch.
     @objcdispatch pair_same(a::KindOf{TestNSString}, b::KindOf{TestNSString}) =
         (typeof(a), typeof(b))
     @test pair_same(mut, str) === (TestNSMutableString, TestNSString)
     @test pair_same(str, mut) === (TestNSString, TestNSMutableString)
 
-    # different `KindOf{T}` parents in a single signature
-    @objcdispatch pair_mixed(a::KindOf{TestNSString}, b::KindOf{TestNSOperationQueue}) =
-        (typeof(a), typeof(b))
-    @test pair_mixed(mut, queue) === (TestNSMutableString, TestNSOperationQueue)
+    # different `KindOf{T}` parents in a single signature — also covers
+    # the cross-hierarchy method created at top level above (open_pair).
+    @test open_pair(mut, queue) === (TestNSMutableString, TestNSOperationQueue)
+    @test_throws MethodError open_pair(queue, queue)
+    @test_throws MethodError open_pair(mut, mut)
 
     # other positional args may be anonymous-typed (`::SomeType`) — that's
     # a one-element `::` expression and must not be confused for a KindOf
@@ -373,66 +381,15 @@ end
         (typeof(s), T)
     @test with_anon(mut, Int32) === (TestNSMutableString, Int32)
 
-    # `KindOf{T}` with an abstract T (e.g. `Object`) collapses to `T` because
-    # every wrapper is already `<: T` in Julia's type system. The dispatch
-    # site should not be registered, so subsequent `@objcwrapper`s don't
-    # warn that the Union is stale (it never was a Union).
+    # `KindOf{Object}` matches any wrapper (every classkind <: ObjectKind),
+    # and a subclass declared afterwards also routes through it.
     @objcdispatch anyobj(x::KindOf{Object}) = typeof(x)
-    @test !haskey(ObjectiveC.objcdispatch_sites, Object)
-    @test_nowarn @eval @objcwrapper TestNSAnyObjSub <: Object
     @test anyobj(mut) === TestNSMutableString
+    @test anyobj(queue) === TestNSOperationQueue
+    @test_nowarn @eval @objcwrapper TestNSAnyObjSub <: Object
 
-end
-
-# `@objcdispatch open=true` at top level: dispatches on `::Object` with a
-# runtime `inherits_from` guard, so methods remain open to wrappers declared
-# later (e.g. in another package) without re-declaration.
-@objcdispatch open=true open_len_kind(s::KindOf{TestNSString})::Int =
-    Int(@objc [s::id{TestNSString} length]::Culong)
-@objcdispatch open=true open_pair(a::KindOf{TestNSString}, b::KindOf{TestNSOperationQueue}) =
-    (typeof(a), typeof(b))
-# Declaring `TestOpenLateSub <: TestNSString` is intentionally "late" — the
-# `inheritance / @objcdispatch` testset above registered six closed-world
-# dispatch sites on `TestNSString` (testlen, testlen_qualified, concretetype,
-# pair_same, pair_mixed, with_anon), and we want to verify that open=true
-# methods still dispatch on this subclass. The six expected late-subclass
-# warnings are captured here so they don't leak as noise in the test output.
-@test_logs((:warn, r"@objcdispatch testlen\("),
-           (:warn, r"@objcdispatch testlen_qualified\("),
-           (:warn, r"@objcdispatch concretetype\("),
-           (:warn, r"@objcdispatch pair_same\("),
-           (:warn, r"@objcdispatch pair_mixed\("),
-           (:warn, r"@objcdispatch with_anon\("),
-           @eval @objcwrapper TestOpenLateSub <: TestNSString)
-# Isolated parent for the "no-warning" assertion: other tests register
-# closed-world dispatch sites on `TestNSString`, so we need a fresh class.
-@objcwrapper TestOpenRoot <: Object
-@objcdispatch open=true open_root_id(x::KindOf{TestOpenRoot}) = typeof(x)
-@testset "@objcdispatch open=true" begin
-    str1 = "foo"
-    str = TestNSString(@objc [NSString stringWithUTF8String:str1::Ptr{UInt8}]::id{TestNSString})
-    mut = TestNSMutableString(@objc [NSMutableString stringWithUTF8String:"abcd"::Ptr{UInt8}]::id{TestNSMutableString})
-    queue = TestNSOperationQueue(@objc [NSOperationQueue new]::id{TestNSOperationQueue})
-
-    # Open dispatch handles the parent and its descendants.
-    @test open_len_kind(mut) == 4
-    @test open_len_kind(str) == 3
-    # …including wrappers declared *after* the method.
-    late_obj = TestOpenLateSub(@objc [NSString stringWithUTF8String:str1::Ptr{UInt8}]::id{TestOpenLateSub})
-    @test open_len_kind(late_obj) == 3
-    # MethodError when the runtime class doesn't inherit from the
-    # declared `KindOf` parent.
-    @test_throws MethodError open_len_kind(queue)
-
-    # No call-site registration → no late-subclass warning. Verified on an
-    # isolated parent (`TestOpenRoot`) with no closed-world dispatch sites.
-    @test !haskey(ObjectiveC.objcdispatch_sites, TestOpenRoot)
-    @test_nowarn @eval @objcwrapper TestOpenRootSub <: TestOpenRoot
-
-    # Multi-arg `open=true`: every `KindOf{T}` slot gets its own guard.
-    @test open_pair(mut, queue) === (TestNSMutableString, TestNSOperationQueue)
-    @test_throws MethodError open_pair(queue, queue)
-    @test_throws MethodError open_pair(mut, mut)
+    # The legacy `open=true` keyword should now error.
+    @test_throws LoadError @eval @objcdispatch open=true bad_open(x::KindOf{TestNSString}) = nothing
 end
 
 using .Foundation

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -390,6 +390,19 @@ end
 
     # The legacy `open=true` keyword should now error.
     @test_throws LoadError @eval @objcmethod open=true bad_open(x::KindOf{TestNSString}) = nothing
+
+    # Regression: two `@objcmethod` overloads of the same *constructor*
+    # (i.e. `f` is a type, not a generic function) must not both emit the
+    # `(::Object)` entry forwarder. The dedup guard keys methods by
+    # `Type{T}` rather than `typeof(T) == DataType`, otherwise both
+    # overloads emit the entry and Julia 1.12 rejects the redefinition
+    # during precompilation. `@objcwrapper` is `@eval`d so the macro
+    # check runs after the type exists.
+    @eval @objcwrapper TestCtorTarget <: Object
+    @eval @objcmethod TestCtorTarget(x::KindOf{TestNSString}) =
+        TestCtorTarget(reinterpret($id{TestCtorTarget}, $pointer(x)))
+    @test_nowarn @eval @objcmethod TestCtorTarget(x::KindOf{TestNSOperationQueue}) =
+        TestCtorTarget(reinterpret($id{TestCtorTarget}, $pointer(x)))
 end
 
 using .Foundation

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -365,6 +365,15 @@ end
     @objcdispatch with_anon(s::KindOf{TestNSString}, ::Type{T}) where {T<:Integer} =
         (typeof(s), T)
     @test with_anon(mut, Int32) === (TestNSMutableString, Int32)
+
+    # `KindOf{T}` with an abstract T (e.g. `Object`) collapses to `T` because
+    # every wrapper is already `<: T` in Julia's type system. The dispatch
+    # site should not be registered, so subsequent `@objcwrapper`s don't
+    # warn that the Union is stale (it never was a Union).
+    @objcdispatch anyobj(x::KindOf{Object}) = typeof(x)
+    @test !haskey(ObjectiveC.objcdispatch_sites, Object)
+    @test_nowarn @eval @objcwrapper TestNSAnyObjSub <: Object
+    @test anyobj(mut) === TestNSMutableString
 end
 
 using .Foundation

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -211,6 +211,13 @@ end
     @test :length in propertynames(bare)
     @test :UTF8String in propertynames(bare)
     @test bare.length == length(str1)
+
+    # Const-prop on literal property access: `obj.length` must infer the
+    # exact return type, not the Union of every property in the ancestor
+    # chain. Regression guard for the `@inline objc_getproperty` cascade.
+    get_len(s) = s.length
+    @test Base.return_types(get_len, (TestNSString,))[1] === Culong
+    @test Base.return_types(get_len, (TestNSStringBareSub,))[1] === Culong
 end
 
 @testset "@objc blocks" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -304,21 +304,21 @@ end
     #   TestNSMutableString <: TestNSString <: Object
     # plus a sibling TestNSOperationQueue <: Object.
 
-    # inherits_from: walks the Kind lattice
-    @test inherits_from(TestNSString, TestNSString)
-    @test inherits_from(TestNSMutableString, TestNSString)
-    @test inherits_from(TestNSMutableString, Object)
-    @test !inherits_from(TestNSString, TestNSMutableString)
-    @test !inherits_from(TestNSOperationQueue, TestNSString)
-    @test !inherits_from(TestNSString, TestNSOperationQueue)
+    # ObjectiveC.inherits_from: walks the Kind lattice
+    @test ObjectiveC.inherits_from(TestNSString, TestNSString)
+    @test ObjectiveC.inherits_from(TestNSMutableString, TestNSString)
+    @test ObjectiveC.inherits_from(TestNSMutableString, Object)
+    @test !ObjectiveC.inherits_from(TestNSString, TestNSMutableString)
+    @test !ObjectiveC.inherits_from(TestNSOperationQueue, TestNSString)
+    @test !ObjectiveC.inherits_from(TestNSString, TestNSOperationQueue)
     # non-Object types fall through to `classkind = Nothing`
-    @test !inherits_from(Int, TestNSString)
-    @test !inherits_from(TestNSString, Int)
+    @test !ObjectiveC.inherits_from(Int, TestNSString)
+    @test !ObjectiveC.inherits_from(TestNSString, Int)
 
     # the Kind lattice mirrors the ObjC parent chain
-    @test classkind(TestNSMutableString) <: classkind(TestNSString)
-    @test classkind(TestNSString) <: classkind(Object)
-    @test !(classkind(TestNSOperationQueue) <: classkind(TestNSString))
+    @test ObjectiveC.classkind(TestNSMutableString) <: ObjectiveC.classkind(TestNSString)
+    @test ObjectiveC.classkind(TestNSString) <: ObjectiveC.classkind(Object)
+    @test !(ObjectiveC.classkind(TestNSOperationQueue) <: ObjectiveC.classkind(TestNSString))
 
     # id{Sub} ↔ id{Parent} conversion follows the Kind lattice
     raw = @objc [NSMutableString stringWithUTF8String:"abcd"::Ptr{UInt8}]::id{TestNSMutableString}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -381,6 +381,46 @@ end
     @test !haskey(ObjectiveC.objcdispatch_sites, Object)
     @test_nowarn @eval @objcwrapper TestNSAnyObjSub <: Object
     @test anyobj(mut) === TestNSMutableString
+
+end
+
+# `@objcdispatch open=true` at top level: dispatches on `::Object` with a
+# runtime `inherits_from` guard, so methods remain open to wrappers declared
+# later (e.g. in another package) without re-declaration.
+@objcdispatch open=true open_len_kind(s::KindOf{TestNSString})::Int =
+    Int(@objc [s::id{TestNSString} length]::Culong)
+@objcdispatch open=true open_pair(a::KindOf{TestNSString}, b::KindOf{TestNSOperationQueue}) =
+    (typeof(a), typeof(b))
+@objcwrapper TestOpenLateSub <: TestNSString
+# Isolated parent for the "no-warning" assertion: other tests register
+# closed-world dispatch sites on `TestNSString`, so we need a fresh class.
+@objcwrapper TestOpenRoot <: Object
+@objcdispatch open=true open_root_id(x::KindOf{TestOpenRoot}) = typeof(x)
+@testset "@objcdispatch open=true" begin
+    str1 = "foo"
+    str = TestNSString(@objc [NSString stringWithUTF8String:str1::Ptr{UInt8}]::id{TestNSString})
+    mut = TestNSMutableString(@objc [NSMutableString stringWithUTF8String:"abcd"::Ptr{UInt8}]::id{TestNSMutableString})
+    queue = TestNSOperationQueue(@objc [NSOperationQueue new]::id{TestNSOperationQueue})
+
+    # Open dispatch handles the parent and its descendants.
+    @test open_len_kind(mut) == 4
+    @test open_len_kind(str) == 3
+    # …including wrappers declared *after* the method.
+    late_obj = TestOpenLateSub(@objc [NSString stringWithUTF8String:str1::Ptr{UInt8}]::id{TestOpenLateSub})
+    @test open_len_kind(late_obj) == 3
+    # MethodError when the runtime class doesn't inherit from the
+    # declared `KindOf` parent.
+    @test_throws MethodError open_len_kind(queue)
+
+    # No call-site registration → no late-subclass warning. Verified on an
+    # isolated parent (`TestOpenRoot`) with no closed-world dispatch sites.
+    @test !haskey(ObjectiveC.objcdispatch_sites, TestOpenRoot)
+    @test_nowarn @eval @objcwrapper TestOpenRootSub <: TestOpenRoot
+
+    # Multi-arg `open=true`: every `KindOf{T}` slot gets its own guard.
+    @test open_pair(mut, queue) === (TestNSMutableString, TestNSOperationQueue)
+    @test_throws MethodError open_pair(queue, queue)
+    @test_throws MethodError open_pair(mut, mut)
 end
 
 using .Foundation

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -155,6 +155,9 @@ end
 @objcproperties TestNSOperationQueue begin
     @autoproperty name::id{TestNSString} setter=setName
 end
+# bare subclass: no `@objcproperties` of its own, used to verify that
+# `propertynames` inherits the parent's property list.
+@objcwrapper TestNSStringBareSub <: TestNSString
 @testset "@objcproperties" begin
     # immutable object with only read properties
     str1 = "foo"
@@ -189,6 +192,13 @@ end
     @test unsafe_string(queue.name.UTF8String) != str1
     queue.name = immut
     @test unsafe_string(queue.name.UTF8String) == str1
+
+    # subclass without its own @objcproperties block still surfaces the
+    # parent's properties via propertynames.
+    bare = TestNSStringBareSub(@objc [NSString stringWithUTF8String:str1::Ptr{UInt8}]::id{TestNSStringBareSub})
+    @test :length in propertynames(bare)
+    @test :UTF8String in propertynames(bare)
+    @test bare.length == length(str1)
 end
 
 @testset "@objc blocks" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -136,6 +136,18 @@ end
     @test_throws UndefRefError TestNSString(nil)
 end
 
+# `@objcwrapper Foo` (no explicit parent) must work from a module that hasn't
+# brought `Object` into scope; the default super has to be fully qualified.
+module NoObjectImport
+    import ..ObjectiveC
+    import ..ObjectiveC: @objcwrapper
+    @objcwrapper NoImportWrapper
+end
+@testset "@objcwrapper default super qualified" begin
+    @test supertype(NoObjectImport.NoImportWrapper) === ObjectiveC.Object
+    @test ObjectiveC.objc_parent(NoObjectImport.NoImportWrapper) === ObjectiveC.Object
+end
+
 @objcproperties TestNSString begin
     @autoproperty length::Culong
     @static if true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -324,6 +324,25 @@ end
     @test_warn r"declared after `@objcdispatch testlen" begin
         @eval @objcwrapper TestLateSub <: TestNSString
     end
+
+    # multiple `KindOf{T}` slots are all substituted (issue: previously only
+    # the first slot was rewritten, leaving the rest as the empty marker).
+    @objcdispatch pair_same(a::KindOf{TestNSString}, b::KindOf{TestNSString}) =
+        (typeof(a), typeof(b))
+    @test pair_same(mut, str) === (TestNSMutableString, TestNSString)
+    @test pair_same(str, mut) === (TestNSString, TestNSMutableString)
+
+    # different `KindOf{T}` parents in a single signature
+    @objcdispatch pair_mixed(a::KindOf{TestNSString}, b::KindOf{TestNSOperationQueue}) =
+        (typeof(a), typeof(b))
+    @test pair_mixed(mut, queue) === (TestNSMutableString, TestNSOperationQueue)
+
+    # other positional args may be anonymous-typed (`::SomeType`) — that's
+    # a one-element `::` expression and must not be confused for a KindOf
+    # slot when locating substitutions.
+    @objcdispatch with_anon(s::KindOf{TestNSString}, ::Type{T}) where {T<:Integer} =
+        (typeof(s), T)
+    @test with_anon(mut, Int32) === (TestNSMutableString, Int32)
 end
 
 using .Foundation

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -259,6 +259,67 @@ end
     end
 end
 
+@testset "inheritance / @objcdispatch" begin
+    # The existing @objcproperties fixture gives us a two-level hierarchy:
+    #   TestNSMutableString <: TestNSString <: Object
+    # plus a sibling TestNSOperationQueue <: Object. We add one more leaf to
+    # have a chain deeper than two without using ObjC inheritance subtleties.
+
+    # inherits_from: walks the parent chain
+    @test inherits_from(TestNSString, TestNSString)
+    @test inherits_from(TestNSMutableString, TestNSString)
+    @test inherits_from(TestNSMutableString, Object)
+    @test !inherits_from(TestNSString, TestNSMutableString)
+    @test !inherits_from(TestNSOperationQueue, TestNSString)
+    @test !inherits_from(TestNSString, TestNSOperationQueue)
+    # non-Object types short-circuit
+    @test !inherits_from(Int, TestNSString)
+    @test !inherits_from(TestNSString, Int)
+
+    # id{Sub} ↔ id{Parent} conversion follows inherits_from
+    raw = @objc [NSMutableString stringWithUTF8String:"abcd"::Ptr{UInt8}]::id{TestNSMutableString}
+    @test raw isa id{TestNSMutableString}
+    @test convert(id{TestNSString}, raw) isa id{TestNSString}
+    @test convert(id{Object}, raw) isa id{Object}
+    @test_throws ArgumentError convert(id{TestNSOperationQueue}, raw)
+    # downcast is allowed through reinterpret only
+    parent_ptr = convert(id{TestNSString}, raw)
+    @test_throws ArgumentError convert(id{TestNSMutableString}, parent_ptr)
+    @test reinterpret(id{TestNSMutableString}, parent_ptr) isa id{TestNSMutableString}
+
+    # KindOf is a bitstype register-sized wrapper
+    @test isbitstype(KindOf{TestNSString})
+    @test sizeof(KindOf{TestNSString}) == sizeof(Ptr{Cvoid})
+
+    # @objcdispatch routes any subclass into the KindOf{Parent} body
+    @objcdispatch testlen(s::KindOf{TestNSString})::Int =
+        Int(@objc [s::id{TestNSString} length]::Culong)
+
+    mut = TestNSMutableString(raw)
+    @test testlen(mut) == 4   # subclass dispatch
+    str = TestNSString(@objc [NSString stringWithUTF8String:"xyz"::Ptr{UInt8}]::id{TestNSString})
+    @test testlen(str) == 3   # exact-type dispatch
+
+    # non-conforming Object → MethodError
+    queue = TestNSOperationQueue(@objc [NSOperationQueue new]::id{TestNSOperationQueue})
+    @test_throws MethodError testlen(queue)
+
+    # qualified `KindOf{T}` is recognized by @objcdispatch
+    @objcdispatch testlen_qualified(s::ObjectiveC.KindOf{TestNSString})::Int =
+        Int(@objc [s::id{TestNSString} length]::Culong)
+    @test testlen_qualified(mut) == 4
+
+    # property access through KindOf walks the @objcproperties chain
+    iface = KindOf{TestNSString}(mut)
+    @test iface.length == 4
+    @test :length in propertynames(iface)
+    @test :UTF8String in propertynames(iface)
+    @test unsafe_string(iface.UTF8String) == "abcd"
+
+    # direct KindOf{T}(::Object) construction rejects non-conforming objects
+    @test_throws ArgumentError KindOf{TestNSString}(queue)
+end
+
 using .Foundation
 @testset "foundation" begin
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -288,18 +288,18 @@ end
     end
 end
 
-# `@objcdispatch` methods declared at top level: they should dispatch on
+# `@objcmethod` methods declared at top level: they should dispatch on
 # subclasses declared later, even from outside the current testset.
-@objcdispatch open_len_kind(s::KindOf{TestNSString})::Int =
+@objcmethod open_len_kind(s::KindOf{TestNSString})::Int =
     Int(@objc [s::id{TestNSString} length]::Culong)
-@objcdispatch open_pair(a::KindOf{TestNSString}, b::KindOf{TestNSOperationQueue}) =
+@objcmethod open_pair(a::KindOf{TestNSString}, b::KindOf{TestNSOperationQueue}) =
     (typeof(a), typeof(b))
 # Subclass declared *after* the methods above — Kind-lattice dispatch
 # means it just works, with no warning, no registry, and no Union to
 # refreeze.
 @objcwrapper TestLateSub <: TestNSString
 
-@testset "inheritance / @objcdispatch" begin
+@testset "inheritance / @objcmethod" begin
     # The existing @objcproperties fixture gives us a two-level hierarchy:
     #   TestNSMutableString <: TestNSString <: Object
     # plus a sibling TestNSOperationQueue <: Object.
@@ -335,25 +335,25 @@ end
     str = TestNSString(@objc [NSString stringWithUTF8String:"xyz"::Ptr{UInt8}]::id{TestNSString})
     queue = TestNSOperationQueue(@objc [NSOperationQueue new]::id{TestNSOperationQueue})
 
-    # @objcdispatch dispatches on the Kind lattice — parent and every
+    # @objcmethod dispatches on the Kind lattice — parent and every
     # subclass route to the same body.
     @test open_len_kind(mut) == 4    # subclass
     @test open_len_kind(str) == 3    # exact type
-    # …including subclasses declared *after* the @objcdispatch site.
+    # …including subclasses declared *after* the @objcmethod site.
     late = TestLateSub(@objc [NSString stringWithUTF8String:"xyz"::Ptr{UInt8}]::id{TestLateSub})
     @test open_len_kind(late) == 3
 
     # non-conforming class → MethodError on the body method.
     @test_throws MethodError open_len_kind(queue)
 
-    # qualified `KindOf{T}` is recognized by @objcdispatch
-    @objcdispatch testlen_qualified(s::ObjectiveC.KindOf{TestNSString})::Int =
+    # qualified `KindOf{T}` is recognized by @objcmethod
+    @objcmethod testlen_qualified(s::ObjectiveC.KindOf{TestNSString})::Int =
         Int(@objc [s::id{TestNSString} length]::Culong)
     @test testlen_qualified(mut) == 4
 
     # the body sees the concrete subclass — `typeof(x)` resolves through
     # the entry forwarder.
-    @objcdispatch concretetype(s::KindOf{TestNSString}) = typeof(s)
+    @objcmethod concretetype(s::KindOf{TestNSString}) = typeof(s)
     @test concretetype(mut) === TestNSMutableString
     @test concretetype(str) === TestNSString
 
@@ -363,7 +363,7 @@ end
 
     # multiple `KindOf{T}` slots: every slot is independently lowered into
     # trait dispatch.
-    @objcdispatch pair_same(a::KindOf{TestNSString}, b::KindOf{TestNSString}) =
+    @objcmethod pair_same(a::KindOf{TestNSString}, b::KindOf{TestNSString}) =
         (typeof(a), typeof(b))
     @test pair_same(mut, str) === (TestNSMutableString, TestNSString)
     @test pair_same(str, mut) === (TestNSString, TestNSMutableString)
@@ -377,19 +377,19 @@ end
     # other positional args may be anonymous-typed (`::SomeType`) — that's
     # a one-element `::` expression and must not be confused for a KindOf
     # slot when locating substitutions.
-    @objcdispatch with_anon(s::KindOf{TestNSString}, ::Type{T}) where {T<:Integer} =
+    @objcmethod with_anon(s::KindOf{TestNSString}, ::Type{T}) where {T<:Integer} =
         (typeof(s), T)
     @test with_anon(mut, Int32) === (TestNSMutableString, Int32)
 
     # `KindOf{Object}` matches any wrapper (every classkind <: ObjectKind),
     # and a subclass declared afterwards also routes through it.
-    @objcdispatch anyobj(x::KindOf{Object}) = typeof(x)
+    @objcmethod anyobj(x::KindOf{Object}) = typeof(x)
     @test anyobj(mut) === TestNSMutableString
     @test anyobj(queue) === TestNSOperationQueue
     @test_nowarn @eval @objcwrapper TestNSAnyObjSub <: Object
 
     # The legacy `open=true` keyword should now error.
-    @test_throws LoadError @eval @objcdispatch open=true bad_open(x::KindOf{TestNSString}) = nothing
+    @test_throws LoadError @eval @objcmethod open=true bad_open(x::KindOf{TestNSString}) = nothing
 end
 
 using .Foundation

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -262,8 +262,7 @@ end
 @testset "inheritance / @objcdispatch" begin
     # The existing @objcproperties fixture gives us a two-level hierarchy:
     #   TestNSMutableString <: TestNSString <: Object
-    # plus a sibling TestNSOperationQueue <: Object. We add one more leaf to
-    # have a chain deeper than two without using ObjC inheritance subtleties.
+    # plus a sibling TestNSOperationQueue <: Object.
 
     # inherits_from: walks the parent chain
     @test inherits_from(TestNSString, TestNSString)
@@ -287,20 +286,23 @@ end
     @test_throws ArgumentError convert(id{TestNSMutableString}, parent_ptr)
     @test reinterpret(id{TestNSMutableString}, parent_ptr) isa id{TestNSMutableString}
 
-    # KindOf is a bitstype register-sized wrapper
-    @test isbitstype(KindOf{TestNSString})
-    @test sizeof(KindOf{TestNSString}) == sizeof(Ptr{Cvoid})
+    # objc_subtree enumerates parent + descendants via the objc_parent method table
+    sub = ObjectiveC.objc_subtree(TestNSString)
+    @test TestNSString in sub
+    @test TestNSMutableString in sub
+    @test !(TestNSOperationQueue in sub)
+    @test ObjectiveC.objc_subtree(TestNSMutableString) == [TestNSMutableString]
 
-    # @objcdispatch routes any subclass into the KindOf{Parent} body
+    # @objcdispatch expands KindOf{Parent} into Union{Parent, descendants...}
     @objcdispatch testlen(s::KindOf{TestNSString})::Int =
         Int(@objc [s::id{TestNSString} length]::Culong)
 
     mut = TestNSMutableString(raw)
-    @test testlen(mut) == 4   # subclass dispatch
     str = TestNSString(@objc [NSString stringWithUTF8String:"xyz"::Ptr{UInt8}]::id{TestNSString})
+    @test testlen(mut) == 4   # subclass dispatch
     @test testlen(str) == 3   # exact-type dispatch
 
-    # non-conforming Object → MethodError
+    # non-conforming Object → MethodError (Julia's normal Union dispatch)
     queue = TestNSOperationQueue(@objc [NSOperationQueue new]::id{TestNSOperationQueue})
     @test_throws MethodError testlen(queue)
 
@@ -309,15 +311,19 @@ end
         Int(@objc [s::id{TestNSString} length]::Culong)
     @test testlen_qualified(mut) == 4
 
-    # property access through KindOf walks the @objcproperties chain
-    iface = KindOf{TestNSString}(mut)
-    @test iface.length == 4
-    @test :length in propertynames(iface)
-    @test :UTF8String in propertynames(iface)
-    @test unsafe_string(iface.UTF8String) == "abcd"
+    # the body sees the concrete subclass (no wrapper to erase it)
+    @objcdispatch concretetype(s::KindOf{TestNSString}) = typeof(s)
+    @test concretetype(mut) === TestNSMutableString
+    @test concretetype(str) === TestNSString
 
-    # direct KindOf{T}(::Object) construction rejects non-conforming objects
-    @test_throws ArgumentError KindOf{TestNSString}(queue)
+    # property access works natively — no wrapper involved
+    @test mut.length == 4
+    @test unsafe_string(mut.UTF8String) == "abcd"
+
+    # late-subclass warning: declaring a subclass after `@objcdispatch` warns
+    @test_warn r"declared after `@objcdispatch testlen" begin
+        @eval @objcwrapper TestLateSub <: TestNSString
+    end
 end
 
 using .Foundation

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -391,7 +391,19 @@ end
     Int(@objc [s::id{TestNSString} length]::Culong)
 @objcdispatch open=true open_pair(a::KindOf{TestNSString}, b::KindOf{TestNSOperationQueue}) =
     (typeof(a), typeof(b))
-@objcwrapper TestOpenLateSub <: TestNSString
+# Declaring `TestOpenLateSub <: TestNSString` is intentionally "late" — the
+# `inheritance / @objcdispatch` testset above registered six closed-world
+# dispatch sites on `TestNSString` (testlen, testlen_qualified, concretetype,
+# pair_same, pair_mixed, with_anon), and we want to verify that open=true
+# methods still dispatch on this subclass. The six expected late-subclass
+# warnings are captured here so they don't leak as noise in the test output.
+@test_logs((:warn, r"@objcdispatch testlen\("),
+           (:warn, r"@objcdispatch testlen_qualified\("),
+           (:warn, r"@objcdispatch concretetype\("),
+           (:warn, r"@objcdispatch pair_same\("),
+           (:warn, r"@objcdispatch pair_mixed\("),
+           (:warn, r"@objcdispatch with_anon\("),
+           @eval @objcwrapper TestOpenLateSub <: TestNSString)
 # Isolated parent for the "no-warning" assertion: other tests register
 # closed-world dispatch sites on `TestNSString`, so we need a fresh class.
 @objcwrapper TestOpenRoot <: Object


### PR DESCRIPTION
Today, `@objcwrapper Foo <: Bar` emits an abstract `Foo` plus a concrete `FooInstance`. Anything stored as a `Foo` (containers, struct fields, inferred return types) carries an abstract type, which boxes in `Vector{Foo}`, breaks inference through property chains, and triggers dynamic dispatch in profiles (cf. [vchuravy's profile](https://github.com/JuliaInterop/ObjectiveC.jl/issues/13#issuecomment-3102797561)).

The reason we do this is because ObjC's class hierarchy is concrete inheritance with state at every level. For example, `NSMutableString` is a concrete class with fields and methods, and `NSString` is *also* a concrete class with fields and methods that `NSMutableString` extends. Julia's type system forbids this: only abstract types can have subtypes, only leaves can be concrete. There is no Julia equivalent to "a concrete struct that inherits from another concrete struct."

With this PR, each `@objcwrapper Foo <: Bar` now emits *two* parallel definitions:

```julia
struct Foo <: Object                        # concrete leaf (storage)
  ptr::id{Foo}
end
abstract type FooKind <: BarKind end        # parallel lattice (dispatch)
classkind(::Type{Foo}) = FooKind
```

Crucially, the inheritance stays flat: every wrapper is `<: Object` directly so that `Vector{NSString}` is bits-packed and inference sees fixed types through property access.

This of course breaks dispatch on "non-leaf" classes, for which we introduce a parallel Kind lattice used by `@objcmethod` methods:

```julia
@objcmethod foo(obj::KindOf{Bar}) = ...
```

The macro `KindOf{T}` lowers to trait dispatch on `Type{<:classkind(T)}` plus a method that forwards from untyped `Object` inputs. Multiple sites on the same function compose naturally -- Julia's dispatch picks the most specific Kind at the call site -- and downstream wrappers automatically participate by virtue of `SubKind <: ParentKind`. When the static type is known at the call site (the common case), the entry-then-body chain folds at compile time, so the trait dispatch is often zero-cost.

Closes #13 