### PR TITLE
Improve code prevenance for @autoreleasepool functions

### DIFF
--- a/src/foundation.jl
+++ b/src/foundation.jl
@@ -628,11 +628,11 @@ macro autoreleasepool(ex...)
         # function definition, short form
         sig, body = code.args
         @assert Meta.isexpr(body, :block)
-        managed_body = quote
-            $f() do
+        managed_body = Expr(:block, __source__,
+            :($f() do
                 $body
-            end
-        end
+            end)
+        )
         esc(Expr(:(=), sig, managed_body))
     elseif Meta.isexpr(code, :function)
         # function definition, long form
@@ -640,11 +640,11 @@ macro autoreleasepool(ex...)
         @assert Meta.isexpr(sig, :call) || Meta.isexpr(sig, :where)
         body = code.args[2]
         @assert Meta.isexpr(body, :block)
-        managed_body = quote
-            $f() do
+        managed_body = Expr(:block, __source__,
+            :($f() do
                 $body
-            end
-        end
+            end)
+        )
         esc(Expr(:function, sig, managed_body))
     else
         # code block


### PR DESCRIPTION
This has bothered me for a while since it makes error messages much harder to parse. May also fix codecov not picking up coverage of the function definition line if annotated with `@autoreleasepool`.

<details>

<summary>test.jl</summary>

```julia
using ObjectiveC
ObjectiveC.@autoreleasepool autothrowequal() = error()
ObjectiveC.@autoreleasepool function autothrowfunc()
    error()
end
function autothrowblock()
    ObjectiveC.@autoreleasepool error()
end

```

</details>


Old:
```julia-repl
julia> include("test.jl"); methods(autothrowequal)
# 1 method for generic function "autothrowequal" from Main:
 [1] autothrowequal()
     @ ~/.julia/dev/ObjectiveC/src/foundation.jl:632

julia> methods(autothrowfunc)
# 1 method for generic function "autothrowfunc" from Main:
 [1] autothrowfunc()
     @ ~/.julia/dev/ObjectiveC/src/foundation.jl:644

julia> methods(autothrowblock)
# 1 method for generic function "autothrowblock" from Main:
 [1] autothrowblock()
     @ ~/.julia/dev/ObjectiveC/test.jl:6
```

New:
```julia-repl
julia> include("test.jl"); methods(autothrowequal)
# 1 method for generic function "autothrowequal" from Main:
 [1] autothrowequal()
     @ ~/.julia/dev/ObjectiveC/test.jl:2

julia> methods(autothrowfunc)
# 1 method for generic function "autothrowfunc" from Main:
 [1] autothrowfunc()
     @ ~/.julia/dev/ObjectiveC/test.jl:3

julia> methods(autothrowblock)
# 1 method for generic function "autothrowblock" from Main:
 [1] autothrowblock()
     @ ~/.julia/dev/ObjectiveC/test.jl:6
```