### PR TITLE
Speed up `@objc` message sends

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ObjectiveC"
 uuid = "e86c9b32-1129-44ac-8ea0-90d5bb39ded9"
-version = "5.1.0"
+version = "5.2.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -16,11 +16,34 @@ end
 
 Base.unsafe_convert(::Type{Ptr{Cvoid}}, sel::Selector) = sel.ptr
 
+selptr(name) = ccall(:sel_registerName, Ptr{Cvoid}, (Ptr{Cchar},), name)
+
 function Selector(name)
-    Selector(ccall(:sel_registerName, Ptr{Cvoid}, (Ptr{Cchar},), name))
+    Selector(selptr(name))
 end
 
 @static if VERSION >= v"1.12"
+    mutable struct SelRef
+        @atomic ptr::Ptr{Cvoid}
+        const name::String
+
+        function SelRef(name::String)
+            ref = new(C_NULL, name)
+            ccall(:jl_set_precompile_field_replace, Cvoid, (Any, Any, Any),
+                  ref, :ptr, C_NULL)
+            return ref
+        end
+    end
+
+    @inline function (ref::SelRef)()
+        ptr = @atomic :monotonic ref.ptr
+        if ptr == C_NULL
+            ptr = selptr(ref.name)
+            @atomic :monotonic ref.ptr = ptr
+        end
+        return ptr
+    end
+
     mutable struct ClassRef
         @atomic ptr::Ptr{Cvoid}
         const name::String
@@ -36,7 +59,7 @@ end
     @inline function (ref::ClassRef)()
         ptr = @atomic :monotonic ref.ptr
         if ptr == C_NULL
-            ptr = classptr(ref.name)
+            ptr = ccall(:objc_getClass, Ptr{Cvoid}, (Ptr{Cchar},), ref.name)
             ptr != C_NULL && (@atomic :monotonic ref.ptr = ptr)
         end
         return ptr

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -20,6 +20,29 @@ function Selector(name)
     Selector(ccall(:sel_registerName, Ptr{Cvoid}, (Ptr{Cchar},), name))
 end
 
+@static if VERSION >= v"1.12"
+    mutable struct ClassRef
+        @atomic ptr::Ptr{Cvoid}
+        const name::String
+
+        function ClassRef(name::String)
+            ref = new(C_NULL, name)
+            ccall(:jl_set_precompile_field_replace, Cvoid, (Any, Any, Any),
+                  ref, :ptr, C_NULL)
+            return ref
+        end
+    end
+
+    @inline function (ref::ClassRef)()
+        ptr = @atomic :monotonic ref.ptr
+        if ptr == C_NULL
+            ptr = classptr(ref.name)
+            ptr != C_NULL && (@atomic :monotonic ref.ptr = ptr)
+        end
+        return ptr
+    end
+end
+
 macro sel_str(name)
     Selector(name)
 end

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -30,17 +30,12 @@ function flatvcat(ex::Expr)
 end
 
 function objc_selector_expr(msg)
-    if isdefined(Base, :OncePerProcess)
-        name = String(msg)
-        # Selector registration is idempotent and independent of class realization, so it
-        # is safe to cache per process. Class lookup is different: `objc_getClass` can fail
-        # before a framework is loaded and succeed later, so do not mirror this for classes.
-        once = Base.OncePerProcess{Selector}() do
-            Selector(name)
-        end
-        return :(($once)())
+    name = String(msg)
+    @static if VERSION >= v"1.12"
+        ref = SelRef(name)
+        return :(($ref)())
     else
-        return :(Selector($(String(msg))))
+        return :(Selector($name))
     end
 end
 

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -239,11 +239,15 @@ function emit_msgsend(receiver, receiver_typ, rettyp, argtyps, argvals)
     end
 end
 
+# `@objc` is often the whole body of tiny wrapper/property methods. The inline
+# gc-safe transition enlarged that body enough to miss the inliner in loops, so
+# mark the generated expression inline while keeping the traced send emitted once.
 function class_message(class_name, msg, rettyp, argtyps, argvals)
     # We follow Julia's ABI implementation, so ccall/@ccall will handle the sret box.
     send = emit_msgsend(:class, :(Ptr{Cvoid}), rettyp, argtyps, argvals)
 
     quote
+        $(Expr(:meta, :inline))
         class = $(objc_class_expr(class_name))
         sel = $(objc_selector_expr(msg))
         @static if $tracing
@@ -257,14 +261,10 @@ function class_message(class_name, msg, rettyp, argtyps, argvals)
         end
         # Runtime tracing hook (see tracing.jl): one global read + predicted branch when off.
         obj_sub = tracing_subscriber[]
-        if obj_sub == C_NULL
-            ret = $send
-        else
-            obj_t0 = tracing_clock()
-            ret = $send
-            tracing_dispatch(obj_sub, $(QuoteNode(Symbol(class_name))),
-                             $(QuoteNode(Symbol(msg))), obj_t0, tracing_clock())
-        end
+        obj_t0 = obj_sub == C_NULL ? UInt64(0) : tracing_clock()
+        ret = $send
+        obj_sub == C_NULL || tracing_dispatch(obj_sub, $(QuoteNode(Symbol(class_name))),
+                                              $(QuoteNode(Symbol(msg))), obj_t0, tracing_clock())
         @static if $tracing
             if $rettyp !== Nothing
                 Core.print(io, "  ")
@@ -282,6 +282,7 @@ function instance_message(instance, typ, msg, rettyp, argtyps, argvals, class_la
     send = emit_msgsend(instance, :(id{Object}), rettyp, argtyps, argvals)
 
     quote
+        $(Expr(:meta, :inline))
         sel = $(objc_selector_expr(msg))
         @static if $tracing
             io = Core.stderr
@@ -296,14 +297,10 @@ function instance_message(instance, typ, msg, rettyp, argtyps, argvals, class_la
         end
         # Runtime tracing hook (see tracing.jl): one global read + predicted branch when off.
         obj_sub = tracing_subscriber[]
-        if obj_sub == C_NULL
-            ret = $send
-        else
-            obj_t0 = tracing_clock()
-            ret = $send
-            tracing_dispatch(obj_sub, $(QuoteNode(class_label)),
-                             $(QuoteNode(Symbol(msg))), obj_t0, tracing_clock())
-        end
+        obj_t0 = obj_sub == C_NULL ? UInt64(0) : tracing_clock()
+        ret = $send
+        obj_sub == C_NULL || tracing_dispatch(obj_sub, $(QuoteNode(class_label)),
+                                              $(QuoteNode(Symbol(msg))), obj_t0, tracing_clock())
         @static if $tracing
             if $rettyp !== Nothing
                 Core.print(io, "  ")

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -44,6 +44,20 @@ function objc_selector_expr(msg)
     end
 end
 
+function objc_class_expr(class_name)
+    name = String(class_name)
+    @static if VERSION >= v"1.12"
+        ref = ClassRef(name)
+        return quote
+            class = ($ref)()
+            class == C_NULL && error($("Couldn't find class $name"))
+            class
+        end
+    else
+        return :(Class($name))
+    end
+end
+
 # A best-effort, compile-time class label for tracing: `id{MTLFoo}` becomes :MTLFoo,
 # and a plain wrapper type becomes its name. Only used to annotate trace records.
 function objc_label(typ)
@@ -232,7 +246,7 @@ function class_message(class_name, msg, rettyp, argtyps, argvals)
     end
 
     quote
-        class = Class($(String(class_name)))
+        class = $(objc_class_expr(class_name))
         sel = $(objc_selector_expr(msg))
         @static if $tracing
             io = Core.stderr

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -183,13 +183,12 @@ function render_c_arg(io, obj, typ)
     end
 end
 
-# ensure that the GC can run during a ccall. this is only safe if callbacks
-# into Julia transition back to GC-unsafe, which is the case on Julia 1.10+.
+# ensure that the GC can run during a ccall on Julia 1.10/1.11. this is only
+# safe if callbacks into Julia transition back to GC-unsafe, which is the case
+# on Julia 1.10+.
 #
 # doing so is tricky, because no GC operations are allowed after the transition,
 # meaning we have to do our own argument conversion instead of relying on ccall.
-#
-# TODO: replace with JuliaLang/julia#49933 once merged
 function make_gcsafe(ex)
     # decode the ccall
     if !Meta.isexpr(ex, :call) || ex.args[1] != :ccall
@@ -228,22 +227,26 @@ function make_gcsafe(ex)
     return code
 end
 
-function class_message(class_name, msg, rettyp, argtyps, argvals)
-    send = if ABI.use_stret(rettyp)
-        # we follow Julia's ABI implementation,
-        # so ccall will handle the sret box
-        make_gcsafe(:(
-            ccall(:objc_msgSend_stret, $rettyp,
-                  (Ptr{Cvoid}, Ptr{Cvoid}, $(map(esc, argtyps)...)),
-                  class, sel, $(map(esc, argvals)...))
-        ))
+function emit_msgsend(receiver, receiver_typ, rettyp, argtyps, argvals)
+    msgsend_fn = ABI.use_stret(rettyp) ? :objc_msgSend_stret : :objc_msgSend
+    vals = Any[receiver, :sel, map(esc, argvals)...]
+    typs = Any[receiver_typ, :(Ptr{Cvoid}), map(esc, argtyps)...]
+
+    @static if VERSION >= v"1.12"
+        argpairs = Any[Expr(:(::), val, typ) for (val, typ) in zip(vals, typs)]
+        return Expr(:macrocall, GlobalRef(Base, Symbol("@ccall")),
+                    LineNumberNode(0, :none),
+                    Expr(:(=), :gc_safe, true),
+                    Expr(:(::), Expr(:call, msgsend_fn, argpairs...), rettyp))
     else
-        make_gcsafe(:(
-            ccall(:objc_msgSend, $rettyp,
-                  (Ptr{Cvoid}, Ptr{Cvoid}, $(map(esc, argtyps)...)),
-                  class, sel, $(map(esc, argvals)...))
-        ))
+        return make_gcsafe(Expr(:call, :ccall, QuoteNode(msgsend_fn), rettyp,
+                                Expr(:tuple, typs...), vals...))
     end
+end
+
+function class_message(class_name, msg, rettyp, argtyps, argvals)
+    # We follow Julia's ABI implementation, so ccall/@ccall will handle the sret box.
+    send = emit_msgsend(:class, :(Ptr{Cvoid}), rettyp, argtyps, argvals)
 
     quote
         class = $(objc_class_expr(class_name))
@@ -280,21 +283,8 @@ end
 
 function instance_message(instance, typ, msg, rettyp, argtyps, argvals, class_label=:id)
     # TODO: use the instance type `typ` to verify when in validation mode?
-    send = if ABI.use_stret(rettyp)
-        # we follow Julia's ABI implementation,
-        # so ccall will handle the sret box
-        make_gcsafe(:(
-            ccall(:objc_msgSend_stret, $rettyp,
-                  (id{Object}, Ptr{Cvoid}, $(map(esc, argtyps)...)),
-                  $instance, sel, $(map(esc, argvals)...))
-        ))
-    else
-        make_gcsafe(:(
-            ccall(:objc_msgSend, $rettyp,
-                  (id{Object}, Ptr{Cvoid}, $(map(esc, argtyps)...)),
-                  $instance, sel, $(map(esc, argvals)...))
-        ))
-    end
+    # We follow Julia's ABI implementation, so ccall/@ccall will handle the sret box.
+    send = emit_msgsend(instance, :(id{Object}), rettyp, argtyps, argvals)
 
     quote
         sel = $(objc_selector_expr(msg))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -120,6 +120,11 @@ end
 
     # chained class + instance calls
     @objc [[NSString alloc]::id{Object} init]::id{Object}
+
+    @test_throws "Couldn't find class ObjectiveCClassCacheRetry" (@objc [ObjectiveCClassCacheRetry new]::id{Object})
+    ObjectiveC.createclass(:ObjectiveCClassCacheRetry, Class(:NSObject))
+    retry_obj = @objc [ObjectiveCClassCacheRetry new]::id{Object}
+    @test retry_obj != nil
 end
 
 @objcwrapper TestNSString <: Object


### PR DESCRIPTION
`@objc` was never tuned, and it ran several times slower than a hand-written
`ccall`. This closes most of that gap.

Class sends re-resolved the class by name every call: `[NSString string]` spent
~28 ns in `objc_getClass`, more than the send itself. A lazy `ClassRef` now
resolves once and caches the pointer, storing only non-NULL results so an
unloaded class still raises and resolves on retry. ~43 → ~13 ns.

The GC-safe transition was hand-rolled around each send. On 1.12 we use
`@ccall gc_safe=true` (JuliaLang/julia#49933), which inlines the transition
instead of making two indirect calls, and drops `make_gcsafe` entirely.
~14 → ~10 ns. Selectors reuse the same precompile-safe cache (`SelRef`) the
classes need, replacing `OncePerProcess`.

Inlining the transition, plus the tracing hook duplicating the send across its
two branches, pushed wrappers like `length(::NSString)` past the inliner
threshold: single calls got faster but loops regressed. Fixed by emitting the
send once and marking the body `@inline`.

Loop, aarch64 / 1.12, `minimum`:

| | before | after |
|---|---|---|
| instance | 12.1 | 8.3 ns |
| class | 40.8 | 10.5 ns |
| property | 7.7 | 4.3 ns |
| with arg | 12.5 | 7.1 ns |

Gated to 1.12+ (`gc_safe` and the precompile hook are 1.12-only); 1.10/1.11
unchanged, tests green on all three. x86_64 `stret` untested (arm64 never takes
it).